### PR TITLE
Fix bugs in fields shape and accessors

### DIFF
--- a/generated/external/com_google_protobuf/conformance/conformance_proto.php
+++ b/generated/external/com_google_protobuf/conformance/conformance_proto.php
@@ -270,7 +270,7 @@ type ConformanceRequestFields = shape (
   ?'requested_output_format' => \conformance\WireFormat_enum_t,
   ?'message_type' => string,
   ?'test_category' => \conformance\TestCategory_enum_t,
-  ?'jspb_encoding_options' => ?\conformance\JspbEncodingConfigFields,
+  ?'jspb_encoding_options' => \conformance\JspbEncodingConfigFields,
   ?'print_unknown_fields' => bool,
   ?'payload' => ConformanceRequest_payload,
 );
@@ -306,7 +306,7 @@ class ConformanceRequest implements \Protobuf\Message {
     if (Shapes::keyExists($s, 'test_category')) $this->test_category = $s['test_category'];
     if (Shapes::keyExists($s, 'jspb_encoding_options')) {
       if ($this->jspb_encoding_options is null) $this->jspb_encoding_options = new \conformance\JspbEncodingConfig();
-      $this->jspb_encoding_options->setFields($s['jspb_encoding_options'] as nonnull);
+      $this->jspb_encoding_options->setFields($s['jspb_encoding_options']);
     }
     if (Shapes::keyExists($s, 'print_unknown_fields')) $this->print_unknown_fields = $s['print_unknown_fields'];
     if (Shapes::keyExists($s, 'payload')) $this->payload = $s['payload'];

--- a/generated/external/com_google_protobuf/conformance/conformance_proto.php
+++ b/generated/external/com_google_protobuf/conformance/conformance_proto.php
@@ -317,6 +317,7 @@ class ConformanceRequest implements \Protobuf\Message {
     if ($this->requested_output_format !== \conformance\WireFormat::FromInt(0)) $s['requested_output_format'] = $this->requested_output_format;
     if ($this->message_type !== '') $s['message_type'] = $this->message_type;
     if ($this->test_category !== \conformance\TestCategory::FromInt(0)) $s['test_category'] = $this->test_category;
+    if ($this->jspb_encoding_options is nonnull) $s['jspb_encoding_options'] = $this->jspb_encoding_options->getNonDefaultFields();
     if ($this->print_unknown_fields !== false) $s['print_unknown_fields'] = $this->print_unknown_fields;
     if ($this->payload is nonnull && $this->payload->WhichOneof() !== ConformanceRequest_payload_oneof_t::NOT_SET) $s['payload'] = $this->payload;
     return $s;

--- a/generated/google/protobuf/api_proto.php
+++ b/generated/google/protobuf/api_proto.php
@@ -67,6 +67,7 @@ class Api implements \Protobuf\Message {
     if (!C\is_empty($this->methods)) $s['methods'] = Vec\map($this->methods, ($v) ==> $v->getNonDefaultFields());
     if (!C\is_empty($this->options)) $s['options'] = Vec\map($this->options, ($v) ==> $v->getNonDefaultFields());
     if ($this->version !== '') $s['version'] = $this->version;
+    if ($this->source_context is nonnull) $s['source_context'] = $this->source_context->getNonDefaultFields();
     if (!C\is_empty($this->mixins)) $s['mixins'] = Vec\map($this->mixins, ($v) ==> $v->getNonDefaultFields());
     if ($this->syntax !== \google\protobuf\Syntax::FromInt(0)) $s['syntax'] = $this->syntax;
     return $s;

--- a/generated/google/protobuf/api_proto.php
+++ b/generated/google/protobuf/api_proto.php
@@ -9,7 +9,7 @@ type ApiFields = shape (
   ?'methods' => vec<\google\protobuf\MethodFields>,
   ?'options' => vec<\google\protobuf\OptionFields>,
   ?'version' => string,
-  ?'source_context' => ?\google\protobuf\SourceContextFields,
+  ?'source_context' => \google\protobuf\SourceContextFields,
   ?'mixins' => vec<\google\protobuf\MixinFields>,
   ?'syntax' => \google\protobuf\Syntax_enum_t,
 );
@@ -53,7 +53,7 @@ class Api implements \Protobuf\Message {
     if (Shapes::keyExists($s, 'version')) $this->version = $s['version'];
     if (Shapes::keyExists($s, 'source_context')) {
       if ($this->source_context is null) $this->source_context = new \google\protobuf\SourceContext();
-      $this->source_context->setFields($s['source_context'] as nonnull);
+      $this->source_context->setFields($s['source_context']);
     }
     if (Shapes::keyExists($s, 'mixins')) {
       $this->mixins = Vec\map($s['mixins'], ($v) ==> { $o = new \google\protobuf\Mixin(); $o->setFields($v); return $o; });

--- a/generated/google/protobuf/api_proto.php
+++ b/generated/google/protobuf/api_proto.php
@@ -45,12 +45,10 @@ class Api implements \Protobuf\Message {
   public function setFields(ApiFields $s = shape()): void {
     if (Shapes::keyExists($s, 'name')) $this->name = $s['name'];
     if (Shapes::keyExists($s, 'methods')) {
-      if ($this->methods is null) $this->methods = new \google\protobuf\Method();
-      $this->methods->setFields($s['methods'] as nonnull);
+      $this->methods = Vec\map($s['methods'], ($v) ==> { $o = new \google\protobuf\Method(); $o->setFields($v); return $o; });
     }
     if (Shapes::keyExists($s, 'options')) {
-      if ($this->options is null) $this->options = new \google\protobuf\Option();
-      $this->options->setFields($s['options'] as nonnull);
+      $this->options = Vec\map($s['options'], ($v) ==> { $o = new \google\protobuf\Option(); $o->setFields($v); return $o; });
     }
     if (Shapes::keyExists($s, 'version')) $this->version = $s['version'];
     if (Shapes::keyExists($s, 'source_context')) {
@@ -58,8 +56,7 @@ class Api implements \Protobuf\Message {
       $this->source_context->setFields($s['source_context'] as nonnull);
     }
     if (Shapes::keyExists($s, 'mixins')) {
-      if ($this->mixins is null) $this->mixins = new \google\protobuf\Mixin();
-      $this->mixins->setFields($s['mixins'] as nonnull);
+      $this->mixins = Vec\map($s['mixins'], ($v) ==> { $o = new \google\protobuf\Mixin(); $o->setFields($v); return $o; });
     }
     if (Shapes::keyExists($s, 'syntax')) $this->syntax = $s['syntax'];
   }
@@ -67,10 +64,10 @@ class Api implements \Protobuf\Message {
   public function getNonDefaultFields(): ApiFields {
     $s = shape();
     if ($this->name !== '') $s['name'] = $this->name;
-    if (!C\is_empty($this->methods)) $s['methods'] = $this->methods;
-    if (!C\is_empty($this->options)) $s['options'] = $this->options;
+    if (!C\is_empty($this->methods)) $s['methods'] = Vec\map($this->methods, ($v) ==> $v->getNonDefaultFields());
+    if (!C\is_empty($this->options)) $s['options'] = Vec\map($this->options, ($v) ==> $v->getNonDefaultFields());
     if ($this->version !== '') $s['version'] = $this->version;
-    if (!C\is_empty($this->mixins)) $s['mixins'] = $this->mixins;
+    if (!C\is_empty($this->mixins)) $s['mixins'] = Vec\map($this->mixins, ($v) ==> $v->getNonDefaultFields());
     if ($this->syntax !== \google\protobuf\Syntax::FromInt(0)) $s['syntax'] = $this->syntax;
     return $s;
   }
@@ -289,8 +286,7 @@ class Method implements \Protobuf\Message {
     if (Shapes::keyExists($s, 'response_type_url')) $this->response_type_url = $s['response_type_url'];
     if (Shapes::keyExists($s, 'response_streaming')) $this->response_streaming = $s['response_streaming'];
     if (Shapes::keyExists($s, 'options')) {
-      if ($this->options is null) $this->options = new \google\protobuf\Option();
-      $this->options->setFields($s['options'] as nonnull);
+      $this->options = Vec\map($s['options'], ($v) ==> { $o = new \google\protobuf\Option(); $o->setFields($v); return $o; });
     }
     if (Shapes::keyExists($s, 'syntax')) $this->syntax = $s['syntax'];
   }
@@ -302,7 +298,7 @@ class Method implements \Protobuf\Message {
     if ($this->request_streaming !== false) $s['request_streaming'] = $this->request_streaming;
     if ($this->response_type_url !== '') $s['response_type_url'] = $this->response_type_url;
     if ($this->response_streaming !== false) $s['response_streaming'] = $this->response_streaming;
-    if (!C\is_empty($this->options)) $s['options'] = $this->options;
+    if (!C\is_empty($this->options)) $s['options'] = Vec\map($this->options, ($v) ==> $v->getNonDefaultFields());
     if ($this->syntax !== \google\protobuf\Syntax::FromInt(0)) $s['syntax'] = $this->syntax;
     return $s;
   }

--- a/generated/google/protobuf/compiler/plugin_proto.php
+++ b/generated/google/protobuf/compiler/plugin_proto.php
@@ -179,6 +179,7 @@ class CodeGeneratorRequest implements \Protobuf\Message {
     if (!C\is_empty($this->file_to_generate)) $s['file_to_generate'] = $this->file_to_generate;
     if ($this->parameter !== '') $s['parameter'] = $this->parameter;
     if (!C\is_empty($this->proto_file)) $s['proto_file'] = Vec\map($this->proto_file, ($v) ==> $v->getNonDefaultFields());
+    if ($this->compiler_version is nonnull) $s['compiler_version'] = $this->compiler_version->getNonDefaultFields();
     return $s;
   }
 
@@ -361,6 +362,7 @@ class CodeGeneratorResponse_File implements \Protobuf\Message {
     if ($this->name !== '') $s['name'] = $this->name;
     if ($this->insertion_point !== '') $s['insertion_point'] = $this->insertion_point;
     if ($this->content !== '') $s['content'] = $this->content;
+    if ($this->generated_code_info is nonnull) $s['generated_code_info'] = $this->generated_code_info->getNonDefaultFields();
     return $s;
   }
 

--- a/generated/google/protobuf/compiler/plugin_proto.php
+++ b/generated/google/protobuf/compiler/plugin_proto.php
@@ -140,7 +140,7 @@ type CodeGeneratorRequestFields = shape (
   ?'file_to_generate' => vec<string>,
   ?'parameter' => string,
   ?'proto_file' => vec<\google\protobuf\FileDescriptorProtoFields>,
-  ?'compiler_version' => ?\google\protobuf\compiler\VersionFields,
+  ?'compiler_version' => \google\protobuf\compiler\VersionFields,
 );
 class CodeGeneratorRequest implements \Protobuf\Message {
   public vec<string> $file_to_generate;
@@ -170,7 +170,7 @@ class CodeGeneratorRequest implements \Protobuf\Message {
     }
     if (Shapes::keyExists($s, 'compiler_version')) {
       if ($this->compiler_version is null) $this->compiler_version = new \google\protobuf\compiler\Version();
-      $this->compiler_version->setFields($s['compiler_version'] as nonnull);
+      $this->compiler_version->setFields($s['compiler_version']);
     }
   }
 
@@ -325,7 +325,7 @@ type CodeGeneratorResponse_FileFields = shape (
   ?'name' => string,
   ?'insertion_point' => string,
   ?'content' => string,
-  ?'generated_code_info' => ?\google\protobuf\GeneratedCodeInfoFields,
+  ?'generated_code_info' => \google\protobuf\GeneratedCodeInfoFields,
 );
 class CodeGeneratorResponse_File implements \Protobuf\Message {
   public string $name;
@@ -353,7 +353,7 @@ class CodeGeneratorResponse_File implements \Protobuf\Message {
     if (Shapes::keyExists($s, 'content')) $this->content = $s['content'];
     if (Shapes::keyExists($s, 'generated_code_info')) {
       if ($this->generated_code_info is null) $this->generated_code_info = new \google\protobuf\GeneratedCodeInfo();
-      $this->generated_code_info->setFields($s['generated_code_info'] as nonnull);
+      $this->generated_code_info->setFields($s['generated_code_info']);
     }
   }
 

--- a/generated/google/protobuf/compiler/plugin_proto.php
+++ b/generated/google/protobuf/compiler/plugin_proto.php
@@ -166,8 +166,7 @@ class CodeGeneratorRequest implements \Protobuf\Message {
     if (Shapes::keyExists($s, 'file_to_generate')) $this->file_to_generate = $s['file_to_generate'];
     if (Shapes::keyExists($s, 'parameter')) $this->parameter = $s['parameter'];
     if (Shapes::keyExists($s, 'proto_file')) {
-      if ($this->proto_file is null) $this->proto_file = new \google\protobuf\FileDescriptorProto();
-      $this->proto_file->setFields($s['proto_file'] as nonnull);
+      $this->proto_file = Vec\map($s['proto_file'], ($v) ==> { $o = new \google\protobuf\FileDescriptorProto(); $o->setFields($v); return $o; });
     }
     if (Shapes::keyExists($s, 'compiler_version')) {
       if ($this->compiler_version is null) $this->compiler_version = new \google\protobuf\compiler\Version();
@@ -179,7 +178,7 @@ class CodeGeneratorRequest implements \Protobuf\Message {
     $s = shape();
     if (!C\is_empty($this->file_to_generate)) $s['file_to_generate'] = $this->file_to_generate;
     if ($this->parameter !== '') $s['parameter'] = $this->parameter;
-    if (!C\is_empty($this->proto_file)) $s['proto_file'] = $this->proto_file;
+    if (!C\is_empty($this->proto_file)) $s['proto_file'] = Vec\map($this->proto_file, ($v) ==> $v->getNonDefaultFields());
     return $s;
   }
 
@@ -491,8 +490,7 @@ class CodeGeneratorResponse implements \Protobuf\Message {
     if (Shapes::keyExists($s, 'error')) $this->error = $s['error'];
     if (Shapes::keyExists($s, 'supported_features')) $this->supported_features = $s['supported_features'];
     if (Shapes::keyExists($s, 'file')) {
-      if ($this->file is null) $this->file = new \google\protobuf\compiler\CodeGeneratorResponse_File();
-      $this->file->setFields($s['file'] as nonnull);
+      $this->file = Vec\map($s['file'], ($v) ==> { $o = new \google\protobuf\compiler\CodeGeneratorResponse_File(); $o->setFields($v); return $o; });
     }
   }
 
@@ -500,7 +498,7 @@ class CodeGeneratorResponse implements \Protobuf\Message {
     $s = shape();
     if ($this->error !== '') $s['error'] = $this->error;
     if ($this->supported_features !== 0) $s['supported_features'] = $this->supported_features;
-    if (!C\is_empty($this->file)) $s['file'] = $this->file;
+    if (!C\is_empty($this->file)) $s['file'] = Vec\map($this->file, ($v) ==> $v->getNonDefaultFields());
     return $s;
   }
 

--- a/generated/google/protobuf/descriptor_proto.php
+++ b/generated/google/protobuf/descriptor_proto.php
@@ -193,6 +193,8 @@ class FileDescriptorProto implements \Protobuf\Message {
     if (!C\is_empty($this->enum_type)) $s['enum_type'] = Vec\map($this->enum_type, ($v) ==> $v->getNonDefaultFields());
     if (!C\is_empty($this->service)) $s['service'] = Vec\map($this->service, ($v) ==> $v->getNonDefaultFields());
     if (!C\is_empty($this->extension)) $s['extension'] = Vec\map($this->extension, ($v) ==> $v->getNonDefaultFields());
+    if ($this->options is nonnull) $s['options'] = $this->options->getNonDefaultFields();
+    if ($this->source_code_info is nonnull) $s['source_code_info'] = $this->source_code_info->getNonDefaultFields();
     if ($this->syntax !== '') $s['syntax'] = $this->syntax;
     return $s;
   }
@@ -502,6 +504,7 @@ class DescriptorProto_ExtensionRange implements \Protobuf\Message {
     $s = shape();
     if ($this->start !== 0) $s['start'] = $this->start;
     if ($this->end !== 0) $s['end'] = $this->end;
+    if ($this->options is nonnull) $s['options'] = $this->options->getNonDefaultFields();
     return $s;
   }
 
@@ -778,6 +781,7 @@ class DescriptorProto implements \Protobuf\Message {
     if (!C\is_empty($this->enum_type)) $s['enum_type'] = Vec\map($this->enum_type, ($v) ==> $v->getNonDefaultFields());
     if (!C\is_empty($this->extension_range)) $s['extension_range'] = Vec\map($this->extension_range, ($v) ==> $v->getNonDefaultFields());
     if (!C\is_empty($this->oneof_decl)) $s['oneof_decl'] = Vec\map($this->oneof_decl, ($v) ==> $v->getNonDefaultFields());
+    if ($this->options is nonnull) $s['options'] = $this->options->getNonDefaultFields();
     if (!C\is_empty($this->reserved_range)) $s['reserved_range'] = Vec\map($this->reserved_range, ($v) ==> $v->getNonDefaultFields());
     if (!C\is_empty($this->reserved_name)) $s['reserved_name'] = $this->reserved_name;
     return $s;
@@ -1308,6 +1312,7 @@ class FieldDescriptorProto implements \Protobuf\Message {
     if ($this->default_value !== '') $s['default_value'] = $this->default_value;
     if ($this->oneof_index !== 0) $s['oneof_index'] = $this->oneof_index;
     if ($this->json_name !== '') $s['json_name'] = $this->json_name;
+    if ($this->options is nonnull) $s['options'] = $this->options->getNonDefaultFields();
     if ($this->proto3_optional !== false) $s['proto3_optional'] = $this->proto3_optional;
     return $s;
   }
@@ -1525,6 +1530,7 @@ class OneofDescriptorProto implements \Protobuf\Message {
   public function getNonDefaultFields(): OneofDescriptorProtoFields {
     $s = shape();
     if ($this->name !== '') $s['name'] = $this->name;
+    if ($this->options is nonnull) $s['options'] = $this->options->getNonDefaultFields();
     return $s;
   }
 
@@ -1749,6 +1755,7 @@ class EnumDescriptorProto implements \Protobuf\Message {
     $s = shape();
     if ($this->name !== '') $s['name'] = $this->name;
     if (!C\is_empty($this->value)) $s['value'] = Vec\map($this->value, ($v) ==> $v->getNonDefaultFields());
+    if ($this->options is nonnull) $s['options'] = $this->options->getNonDefaultFields();
     if (!C\is_empty($this->reserved_range)) $s['reserved_range'] = Vec\map($this->reserved_range, ($v) ==> $v->getNonDefaultFields());
     if (!C\is_empty($this->reserved_name)) $s['reserved_name'] = $this->reserved_name;
     return $s;
@@ -1925,6 +1932,7 @@ class EnumValueDescriptorProto implements \Protobuf\Message {
     $s = shape();
     if ($this->name !== '') $s['name'] = $this->name;
     if ($this->number !== 0) $s['number'] = $this->number;
+    if ($this->options is nonnull) $s['options'] = $this->options->getNonDefaultFields();
     return $s;
   }
 
@@ -2053,6 +2061,7 @@ class ServiceDescriptorProto implements \Protobuf\Message {
     $s = shape();
     if ($this->name !== '') $s['name'] = $this->name;
     if (!C\is_empty($this->method)) $s['method'] = Vec\map($this->method, ($v) ==> $v->getNonDefaultFields());
+    if ($this->options is nonnull) $s['options'] = $this->options->getNonDefaultFields();
     return $s;
   }
 
@@ -2206,6 +2215,7 @@ class MethodDescriptorProto implements \Protobuf\Message {
     if ($this->name !== '') $s['name'] = $this->name;
     if ($this->input_type !== '') $s['input_type'] = $this->input_type;
     if ($this->output_type !== '') $s['output_type'] = $this->output_type;
+    if ($this->options is nonnull) $s['options'] = $this->options->getNonDefaultFields();
     if ($this->client_streaming !== false) $s['client_streaming'] = $this->client_streaming;
     if ($this->server_streaming !== false) $s['server_streaming'] = $this->server_streaming;
     return $s;

--- a/generated/google/protobuf/descriptor_proto.php
+++ b/generated/google/protobuf/descriptor_proto.php
@@ -20,14 +20,13 @@ class FileDescriptorSet implements \Protobuf\Message {
 
   public function setFields(FileDescriptorSetFields $s = shape()): void {
     if (Shapes::keyExists($s, 'file')) {
-      if ($this->file is null) $this->file = new \google\protobuf\FileDescriptorProto();
-      $this->file->setFields($s['file'] as nonnull);
+      $this->file = Vec\map($s['file'], ($v) ==> { $o = new \google\protobuf\FileDescriptorProto(); $o->setFields($v); return $o; });
     }
   }
 
   public function getNonDefaultFields(): FileDescriptorSetFields {
     $s = shape();
-    if (!C\is_empty($this->file)) $s['file'] = $this->file;
+    if (!C\is_empty($this->file)) $s['file'] = Vec\map($this->file, ($v) ==> $v->getNonDefaultFields());
     return $s;
   }
 
@@ -161,20 +160,16 @@ class FileDescriptorProto implements \Protobuf\Message {
     if (Shapes::keyExists($s, 'public_dependency')) $this->public_dependency = $s['public_dependency'];
     if (Shapes::keyExists($s, 'weak_dependency')) $this->weak_dependency = $s['weak_dependency'];
     if (Shapes::keyExists($s, 'message_type')) {
-      if ($this->message_type is null) $this->message_type = new \google\protobuf\DescriptorProto();
-      $this->message_type->setFields($s['message_type'] as nonnull);
+      $this->message_type = Vec\map($s['message_type'], ($v) ==> { $o = new \google\protobuf\DescriptorProto(); $o->setFields($v); return $o; });
     }
     if (Shapes::keyExists($s, 'enum_type')) {
-      if ($this->enum_type is null) $this->enum_type = new \google\protobuf\EnumDescriptorProto();
-      $this->enum_type->setFields($s['enum_type'] as nonnull);
+      $this->enum_type = Vec\map($s['enum_type'], ($v) ==> { $o = new \google\protobuf\EnumDescriptorProto(); $o->setFields($v); return $o; });
     }
     if (Shapes::keyExists($s, 'service')) {
-      if ($this->service is null) $this->service = new \google\protobuf\ServiceDescriptorProto();
-      $this->service->setFields($s['service'] as nonnull);
+      $this->service = Vec\map($s['service'], ($v) ==> { $o = new \google\protobuf\ServiceDescriptorProto(); $o->setFields($v); return $o; });
     }
     if (Shapes::keyExists($s, 'extension')) {
-      if ($this->extension is null) $this->extension = new \google\protobuf\FieldDescriptorProto();
-      $this->extension->setFields($s['extension'] as nonnull);
+      $this->extension = Vec\map($s['extension'], ($v) ==> { $o = new \google\protobuf\FieldDescriptorProto(); $o->setFields($v); return $o; });
     }
     if (Shapes::keyExists($s, 'options')) {
       if ($this->options is null) $this->options = new \google\protobuf\FileOptions();
@@ -194,10 +189,10 @@ class FileDescriptorProto implements \Protobuf\Message {
     if (!C\is_empty($this->dependency)) $s['dependency'] = $this->dependency;
     if (!C\is_empty($this->public_dependency)) $s['public_dependency'] = $this->public_dependency;
     if (!C\is_empty($this->weak_dependency)) $s['weak_dependency'] = $this->weak_dependency;
-    if (!C\is_empty($this->message_type)) $s['message_type'] = $this->message_type;
-    if (!C\is_empty($this->enum_type)) $s['enum_type'] = $this->enum_type;
-    if (!C\is_empty($this->service)) $s['service'] = $this->service;
-    if (!C\is_empty($this->extension)) $s['extension'] = $this->extension;
+    if (!C\is_empty($this->message_type)) $s['message_type'] = Vec\map($this->message_type, ($v) ==> $v->getNonDefaultFields());
+    if (!C\is_empty($this->enum_type)) $s['enum_type'] = Vec\map($this->enum_type, ($v) ==> $v->getNonDefaultFields());
+    if (!C\is_empty($this->service)) $s['service'] = Vec\map($this->service, ($v) ==> $v->getNonDefaultFields());
+    if (!C\is_empty($this->extension)) $s['extension'] = Vec\map($this->extension, ($v) ==> $v->getNonDefaultFields());
     if ($this->syntax !== '') $s['syntax'] = $this->syntax;
     return $s;
   }
@@ -747,36 +742,29 @@ class DescriptorProto implements \Protobuf\Message {
   public function setFields(DescriptorProtoFields $s = shape()): void {
     if (Shapes::keyExists($s, 'name')) $this->name = $s['name'];
     if (Shapes::keyExists($s, 'field')) {
-      if ($this->field is null) $this->field = new \google\protobuf\FieldDescriptorProto();
-      $this->field->setFields($s['field'] as nonnull);
+      $this->field = Vec\map($s['field'], ($v) ==> { $o = new \google\protobuf\FieldDescriptorProto(); $o->setFields($v); return $o; });
     }
     if (Shapes::keyExists($s, 'extension')) {
-      if ($this->extension is null) $this->extension = new \google\protobuf\FieldDescriptorProto();
-      $this->extension->setFields($s['extension'] as nonnull);
+      $this->extension = Vec\map($s['extension'], ($v) ==> { $o = new \google\protobuf\FieldDescriptorProto(); $o->setFields($v); return $o; });
     }
     if (Shapes::keyExists($s, 'nested_type')) {
-      if ($this->nested_type is null) $this->nested_type = new \google\protobuf\DescriptorProto();
-      $this->nested_type->setFields($s['nested_type'] as nonnull);
+      $this->nested_type = Vec\map($s['nested_type'], ($v) ==> { $o = new \google\protobuf\DescriptorProto(); $o->setFields($v); return $o; });
     }
     if (Shapes::keyExists($s, 'enum_type')) {
-      if ($this->enum_type is null) $this->enum_type = new \google\protobuf\EnumDescriptorProto();
-      $this->enum_type->setFields($s['enum_type'] as nonnull);
+      $this->enum_type = Vec\map($s['enum_type'], ($v) ==> { $o = new \google\protobuf\EnumDescriptorProto(); $o->setFields($v); return $o; });
     }
     if (Shapes::keyExists($s, 'extension_range')) {
-      if ($this->extension_range is null) $this->extension_range = new \google\protobuf\DescriptorProto_ExtensionRange();
-      $this->extension_range->setFields($s['extension_range'] as nonnull);
+      $this->extension_range = Vec\map($s['extension_range'], ($v) ==> { $o = new \google\protobuf\DescriptorProto_ExtensionRange(); $o->setFields($v); return $o; });
     }
     if (Shapes::keyExists($s, 'oneof_decl')) {
-      if ($this->oneof_decl is null) $this->oneof_decl = new \google\protobuf\OneofDescriptorProto();
-      $this->oneof_decl->setFields($s['oneof_decl'] as nonnull);
+      $this->oneof_decl = Vec\map($s['oneof_decl'], ($v) ==> { $o = new \google\protobuf\OneofDescriptorProto(); $o->setFields($v); return $o; });
     }
     if (Shapes::keyExists($s, 'options')) {
       if ($this->options is null) $this->options = new \google\protobuf\MessageOptions();
       $this->options->setFields($s['options'] as nonnull);
     }
     if (Shapes::keyExists($s, 'reserved_range')) {
-      if ($this->reserved_range is null) $this->reserved_range = new \google\protobuf\DescriptorProto_ReservedRange();
-      $this->reserved_range->setFields($s['reserved_range'] as nonnull);
+      $this->reserved_range = Vec\map($s['reserved_range'], ($v) ==> { $o = new \google\protobuf\DescriptorProto_ReservedRange(); $o->setFields($v); return $o; });
     }
     if (Shapes::keyExists($s, 'reserved_name')) $this->reserved_name = $s['reserved_name'];
   }
@@ -784,13 +772,13 @@ class DescriptorProto implements \Protobuf\Message {
   public function getNonDefaultFields(): DescriptorProtoFields {
     $s = shape();
     if ($this->name !== '') $s['name'] = $this->name;
-    if (!C\is_empty($this->field)) $s['field'] = $this->field;
-    if (!C\is_empty($this->extension)) $s['extension'] = $this->extension;
-    if (!C\is_empty($this->nested_type)) $s['nested_type'] = $this->nested_type;
-    if (!C\is_empty($this->enum_type)) $s['enum_type'] = $this->enum_type;
-    if (!C\is_empty($this->extension_range)) $s['extension_range'] = $this->extension_range;
-    if (!C\is_empty($this->oneof_decl)) $s['oneof_decl'] = $this->oneof_decl;
-    if (!C\is_empty($this->reserved_range)) $s['reserved_range'] = $this->reserved_range;
+    if (!C\is_empty($this->field)) $s['field'] = Vec\map($this->field, ($v) ==> $v->getNonDefaultFields());
+    if (!C\is_empty($this->extension)) $s['extension'] = Vec\map($this->extension, ($v) ==> $v->getNonDefaultFields());
+    if (!C\is_empty($this->nested_type)) $s['nested_type'] = Vec\map($this->nested_type, ($v) ==> $v->getNonDefaultFields());
+    if (!C\is_empty($this->enum_type)) $s['enum_type'] = Vec\map($this->enum_type, ($v) ==> $v->getNonDefaultFields());
+    if (!C\is_empty($this->extension_range)) $s['extension_range'] = Vec\map($this->extension_range, ($v) ==> $v->getNonDefaultFields());
+    if (!C\is_empty($this->oneof_decl)) $s['oneof_decl'] = Vec\map($this->oneof_decl, ($v) ==> $v->getNonDefaultFields());
+    if (!C\is_empty($this->reserved_range)) $s['reserved_range'] = Vec\map($this->reserved_range, ($v) ==> $v->getNonDefaultFields());
     if (!C\is_empty($this->reserved_name)) $s['reserved_name'] = $this->reserved_name;
     return $s;
   }
@@ -1062,14 +1050,13 @@ class ExtensionRangeOptions implements \Protobuf\Message {
 
   public function setFields(ExtensionRangeOptionsFields $s = shape()): void {
     if (Shapes::keyExists($s, 'uninterpreted_option')) {
-      if ($this->uninterpreted_option is null) $this->uninterpreted_option = new \google\protobuf\UninterpretedOption();
-      $this->uninterpreted_option->setFields($s['uninterpreted_option'] as nonnull);
+      $this->uninterpreted_option = Vec\map($s['uninterpreted_option'], ($v) ==> { $o = new \google\protobuf\UninterpretedOption(); $o->setFields($v); return $o; });
     }
   }
 
   public function getNonDefaultFields(): ExtensionRangeOptionsFields {
     $s = shape();
-    if (!C\is_empty($this->uninterpreted_option)) $s['uninterpreted_option'] = $this->uninterpreted_option;
+    if (!C\is_empty($this->uninterpreted_option)) $s['uninterpreted_option'] = Vec\map($this->uninterpreted_option, ($v) ==> $v->getNonDefaultFields());
     return $s;
   }
 
@@ -1746,16 +1733,14 @@ class EnumDescriptorProto implements \Protobuf\Message {
   public function setFields(EnumDescriptorProtoFields $s = shape()): void {
     if (Shapes::keyExists($s, 'name')) $this->name = $s['name'];
     if (Shapes::keyExists($s, 'value')) {
-      if ($this->value is null) $this->value = new \google\protobuf\EnumValueDescriptorProto();
-      $this->value->setFields($s['value'] as nonnull);
+      $this->value = Vec\map($s['value'], ($v) ==> { $o = new \google\protobuf\EnumValueDescriptorProto(); $o->setFields($v); return $o; });
     }
     if (Shapes::keyExists($s, 'options')) {
       if ($this->options is null) $this->options = new \google\protobuf\EnumOptions();
       $this->options->setFields($s['options'] as nonnull);
     }
     if (Shapes::keyExists($s, 'reserved_range')) {
-      if ($this->reserved_range is null) $this->reserved_range = new \google\protobuf\EnumDescriptorProto_EnumReservedRange();
-      $this->reserved_range->setFields($s['reserved_range'] as nonnull);
+      $this->reserved_range = Vec\map($s['reserved_range'], ($v) ==> { $o = new \google\protobuf\EnumDescriptorProto_EnumReservedRange(); $o->setFields($v); return $o; });
     }
     if (Shapes::keyExists($s, 'reserved_name')) $this->reserved_name = $s['reserved_name'];
   }
@@ -1763,8 +1748,8 @@ class EnumDescriptorProto implements \Protobuf\Message {
   public function getNonDefaultFields(): EnumDescriptorProtoFields {
     $s = shape();
     if ($this->name !== '') $s['name'] = $this->name;
-    if (!C\is_empty($this->value)) $s['value'] = $this->value;
-    if (!C\is_empty($this->reserved_range)) $s['reserved_range'] = $this->reserved_range;
+    if (!C\is_empty($this->value)) $s['value'] = Vec\map($this->value, ($v) ==> $v->getNonDefaultFields());
+    if (!C\is_empty($this->reserved_range)) $s['reserved_range'] = Vec\map($this->reserved_range, ($v) ==> $v->getNonDefaultFields());
     if (!C\is_empty($this->reserved_name)) $s['reserved_name'] = $this->reserved_name;
     return $s;
   }
@@ -2056,8 +2041,7 @@ class ServiceDescriptorProto implements \Protobuf\Message {
   public function setFields(ServiceDescriptorProtoFields $s = shape()): void {
     if (Shapes::keyExists($s, 'name')) $this->name = $s['name'];
     if (Shapes::keyExists($s, 'method')) {
-      if ($this->method is null) $this->method = new \google\protobuf\MethodDescriptorProto();
-      $this->method->setFields($s['method'] as nonnull);
+      $this->method = Vec\map($s['method'], ($v) ==> { $o = new \google\protobuf\MethodDescriptorProto(); $o->setFields($v); return $o; });
     }
     if (Shapes::keyExists($s, 'options')) {
       if ($this->options is null) $this->options = new \google\protobuf\ServiceOptions();
@@ -2068,7 +2052,7 @@ class ServiceDescriptorProto implements \Protobuf\Message {
   public function getNonDefaultFields(): ServiceDescriptorProtoFields {
     $s = shape();
     if ($this->name !== '') $s['name'] = $this->name;
-    if (!C\is_empty($this->method)) $s['method'] = $this->method;
+    if (!C\is_empty($this->method)) $s['method'] = Vec\map($this->method, ($v) ==> $v->getNonDefaultFields());
     return $s;
   }
 
@@ -2495,8 +2479,7 @@ class FileOptions implements \Protobuf\Message {
     if (Shapes::keyExists($s, 'php_metadata_namespace')) $this->php_metadata_namespace = $s['php_metadata_namespace'];
     if (Shapes::keyExists($s, 'ruby_package')) $this->ruby_package = $s['ruby_package'];
     if (Shapes::keyExists($s, 'uninterpreted_option')) {
-      if ($this->uninterpreted_option is null) $this->uninterpreted_option = new \google\protobuf\UninterpretedOption();
-      $this->uninterpreted_option->setFields($s['uninterpreted_option'] as nonnull);
+      $this->uninterpreted_option = Vec\map($s['uninterpreted_option'], ($v) ==> { $o = new \google\protobuf\UninterpretedOption(); $o->setFields($v); return $o; });
     }
   }
 
@@ -2522,7 +2505,7 @@ class FileOptions implements \Protobuf\Message {
     if ($this->php_namespace !== '') $s['php_namespace'] = $this->php_namespace;
     if ($this->php_metadata_namespace !== '') $s['php_metadata_namespace'] = $this->php_metadata_namespace;
     if ($this->ruby_package !== '') $s['ruby_package'] = $this->ruby_package;
-    if (!C\is_empty($this->uninterpreted_option)) $s['uninterpreted_option'] = $this->uninterpreted_option;
+    if (!C\is_empty($this->uninterpreted_option)) $s['uninterpreted_option'] = Vec\map($this->uninterpreted_option, ($v) ==> $v->getNonDefaultFields());
     return $s;
   }
 
@@ -2867,8 +2850,7 @@ class MessageOptions implements \Protobuf\Message {
     if (Shapes::keyExists($s, 'deprecated')) $this->deprecated = $s['deprecated'];
     if (Shapes::keyExists($s, 'map_entry')) $this->map_entry = $s['map_entry'];
     if (Shapes::keyExists($s, 'uninterpreted_option')) {
-      if ($this->uninterpreted_option is null) $this->uninterpreted_option = new \google\protobuf\UninterpretedOption();
-      $this->uninterpreted_option->setFields($s['uninterpreted_option'] as nonnull);
+      $this->uninterpreted_option = Vec\map($s['uninterpreted_option'], ($v) ==> { $o = new \google\protobuf\UninterpretedOption(); $o->setFields($v); return $o; });
     }
   }
 
@@ -2878,7 +2860,7 @@ class MessageOptions implements \Protobuf\Message {
     if ($this->no_standard_descriptor_accessor !== false) $s['no_standard_descriptor_accessor'] = $this->no_standard_descriptor_accessor;
     if ($this->deprecated !== false) $s['deprecated'] = $this->deprecated;
     if ($this->map_entry !== false) $s['map_entry'] = $this->map_entry;
-    if (!C\is_empty($this->uninterpreted_option)) $s['uninterpreted_option'] = $this->uninterpreted_option;
+    if (!C\is_empty($this->uninterpreted_option)) $s['uninterpreted_option'] = Vec\map($this->uninterpreted_option, ($v) ==> $v->getNonDefaultFields());
     return $s;
   }
 
@@ -3097,8 +3079,7 @@ class FieldOptions implements \Protobuf\Message {
     if (Shapes::keyExists($s, 'deprecated')) $this->deprecated = $s['deprecated'];
     if (Shapes::keyExists($s, 'weak')) $this->weak = $s['weak'];
     if (Shapes::keyExists($s, 'uninterpreted_option')) {
-      if ($this->uninterpreted_option is null) $this->uninterpreted_option = new \google\protobuf\UninterpretedOption();
-      $this->uninterpreted_option->setFields($s['uninterpreted_option'] as nonnull);
+      $this->uninterpreted_option = Vec\map($s['uninterpreted_option'], ($v) ==> { $o = new \google\protobuf\UninterpretedOption(); $o->setFields($v); return $o; });
     }
   }
 
@@ -3110,7 +3091,7 @@ class FieldOptions implements \Protobuf\Message {
     if ($this->lazy !== false) $s['lazy'] = $this->lazy;
     if ($this->deprecated !== false) $s['deprecated'] = $this->deprecated;
     if ($this->weak !== false) $s['weak'] = $this->weak;
-    if (!C\is_empty($this->uninterpreted_option)) $s['uninterpreted_option'] = $this->uninterpreted_option;
+    if (!C\is_empty($this->uninterpreted_option)) $s['uninterpreted_option'] = Vec\map($this->uninterpreted_option, ($v) ==> $v->getNonDefaultFields());
     return $s;
   }
 
@@ -3267,14 +3248,13 @@ class OneofOptions implements \Protobuf\Message {
 
   public function setFields(OneofOptionsFields $s = shape()): void {
     if (Shapes::keyExists($s, 'uninterpreted_option')) {
-      if ($this->uninterpreted_option is null) $this->uninterpreted_option = new \google\protobuf\UninterpretedOption();
-      $this->uninterpreted_option->setFields($s['uninterpreted_option'] as nonnull);
+      $this->uninterpreted_option = Vec\map($s['uninterpreted_option'], ($v) ==> { $o = new \google\protobuf\UninterpretedOption(); $o->setFields($v); return $o; });
     }
   }
 
   public function getNonDefaultFields(): OneofOptionsFields {
     $s = shape();
-    if (!C\is_empty($this->uninterpreted_option)) $s['uninterpreted_option'] = $this->uninterpreted_option;
+    if (!C\is_empty($this->uninterpreted_option)) $s['uninterpreted_option'] = Vec\map($this->uninterpreted_option, ($v) ==> $v->getNonDefaultFields());
     return $s;
   }
 
@@ -3369,8 +3349,7 @@ class EnumOptions implements \Protobuf\Message {
     if (Shapes::keyExists($s, 'allow_alias')) $this->allow_alias = $s['allow_alias'];
     if (Shapes::keyExists($s, 'deprecated')) $this->deprecated = $s['deprecated'];
     if (Shapes::keyExists($s, 'uninterpreted_option')) {
-      if ($this->uninterpreted_option is null) $this->uninterpreted_option = new \google\protobuf\UninterpretedOption();
-      $this->uninterpreted_option->setFields($s['uninterpreted_option'] as nonnull);
+      $this->uninterpreted_option = Vec\map($s['uninterpreted_option'], ($v) ==> { $o = new \google\protobuf\UninterpretedOption(); $o->setFields($v); return $o; });
     }
   }
 
@@ -3378,7 +3357,7 @@ class EnumOptions implements \Protobuf\Message {
     $s = shape();
     if ($this->allow_alias !== false) $s['allow_alias'] = $this->allow_alias;
     if ($this->deprecated !== false) $s['deprecated'] = $this->deprecated;
-    if (!C\is_empty($this->uninterpreted_option)) $s['uninterpreted_option'] = $this->uninterpreted_option;
+    if (!C\is_empty($this->uninterpreted_option)) $s['uninterpreted_option'] = Vec\map($this->uninterpreted_option, ($v) ==> $v->getNonDefaultFields());
     return $s;
   }
 
@@ -3492,15 +3471,14 @@ class EnumValueOptions implements \Protobuf\Message {
   public function setFields(EnumValueOptionsFields $s = shape()): void {
     if (Shapes::keyExists($s, 'deprecated')) $this->deprecated = $s['deprecated'];
     if (Shapes::keyExists($s, 'uninterpreted_option')) {
-      if ($this->uninterpreted_option is null) $this->uninterpreted_option = new \google\protobuf\UninterpretedOption();
-      $this->uninterpreted_option->setFields($s['uninterpreted_option'] as nonnull);
+      $this->uninterpreted_option = Vec\map($s['uninterpreted_option'], ($v) ==> { $o = new \google\protobuf\UninterpretedOption(); $o->setFields($v); return $o; });
     }
   }
 
   public function getNonDefaultFields(): EnumValueOptionsFields {
     $s = shape();
     if ($this->deprecated !== false) $s['deprecated'] = $this->deprecated;
-    if (!C\is_empty($this->uninterpreted_option)) $s['uninterpreted_option'] = $this->uninterpreted_option;
+    if (!C\is_empty($this->uninterpreted_option)) $s['uninterpreted_option'] = Vec\map($this->uninterpreted_option, ($v) ==> $v->getNonDefaultFields());
     return $s;
   }
 
@@ -3602,15 +3580,14 @@ class ServiceOptions implements \Protobuf\Message {
   public function setFields(ServiceOptionsFields $s = shape()): void {
     if (Shapes::keyExists($s, 'deprecated')) $this->deprecated = $s['deprecated'];
     if (Shapes::keyExists($s, 'uninterpreted_option')) {
-      if ($this->uninterpreted_option is null) $this->uninterpreted_option = new \google\protobuf\UninterpretedOption();
-      $this->uninterpreted_option->setFields($s['uninterpreted_option'] as nonnull);
+      $this->uninterpreted_option = Vec\map($s['uninterpreted_option'], ($v) ==> { $o = new \google\protobuf\UninterpretedOption(); $o->setFields($v); return $o; });
     }
   }
 
   public function getNonDefaultFields(): ServiceOptionsFields {
     $s = shape();
     if ($this->deprecated !== false) $s['deprecated'] = $this->deprecated;
-    if (!C\is_empty($this->uninterpreted_option)) $s['uninterpreted_option'] = $this->uninterpreted_option;
+    if (!C\is_empty($this->uninterpreted_option)) $s['uninterpreted_option'] = Vec\map($this->uninterpreted_option, ($v) ==> $v->getNonDefaultFields());
     return $s;
   }
 
@@ -3745,8 +3722,7 @@ class MethodOptions implements \Protobuf\Message {
     if (Shapes::keyExists($s, 'deprecated')) $this->deprecated = $s['deprecated'];
     if (Shapes::keyExists($s, 'idempotency_level')) $this->idempotency_level = $s['idempotency_level'];
     if (Shapes::keyExists($s, 'uninterpreted_option')) {
-      if ($this->uninterpreted_option is null) $this->uninterpreted_option = new \google\protobuf\UninterpretedOption();
-      $this->uninterpreted_option->setFields($s['uninterpreted_option'] as nonnull);
+      $this->uninterpreted_option = Vec\map($s['uninterpreted_option'], ($v) ==> { $o = new \google\protobuf\UninterpretedOption(); $o->setFields($v); return $o; });
     }
   }
 
@@ -3754,7 +3730,7 @@ class MethodOptions implements \Protobuf\Message {
     $s = shape();
     if ($this->deprecated !== false) $s['deprecated'] = $this->deprecated;
     if ($this->idempotency_level !== \google\protobuf\MethodOptions_IdempotencyLevel::FromInt(0)) $s['idempotency_level'] = $this->idempotency_level;
-    if (!C\is_empty($this->uninterpreted_option)) $s['uninterpreted_option'] = $this->uninterpreted_option;
+    if (!C\is_empty($this->uninterpreted_option)) $s['uninterpreted_option'] = Vec\map($this->uninterpreted_option, ($v) ==> $v->getNonDefaultFields());
     return $s;
   }
 
@@ -3983,8 +3959,7 @@ class UninterpretedOption implements \Protobuf\Message {
 
   public function setFields(UninterpretedOptionFields $s = shape()): void {
     if (Shapes::keyExists($s, 'name')) {
-      if ($this->name is null) $this->name = new \google\protobuf\UninterpretedOption_NamePart();
-      $this->name->setFields($s['name'] as nonnull);
+      $this->name = Vec\map($s['name'], ($v) ==> { $o = new \google\protobuf\UninterpretedOption_NamePart(); $o->setFields($v); return $o; });
     }
     if (Shapes::keyExists($s, 'identifier_value')) $this->identifier_value = $s['identifier_value'];
     if (Shapes::keyExists($s, 'positive_int_value')) $this->positive_int_value = $s['positive_int_value'];
@@ -3996,7 +3971,7 @@ class UninterpretedOption implements \Protobuf\Message {
 
   public function getNonDefaultFields(): UninterpretedOptionFields {
     $s = shape();
-    if (!C\is_empty($this->name)) $s['name'] = $this->name;
+    if (!C\is_empty($this->name)) $s['name'] = Vec\map($this->name, ($v) ==> $v->getNonDefaultFields());
     if ($this->identifier_value !== '') $s['identifier_value'] = $this->identifier_value;
     if ($this->positive_int_value !== 0) $s['positive_int_value'] = $this->positive_int_value;
     if ($this->negative_int_value !== 0) $s['negative_int_value'] = $this->negative_int_value;
@@ -4331,14 +4306,13 @@ class SourceCodeInfo implements \Protobuf\Message {
 
   public function setFields(SourceCodeInfoFields $s = shape()): void {
     if (Shapes::keyExists($s, 'location')) {
-      if ($this->location is null) $this->location = new \google\protobuf\SourceCodeInfo_Location();
-      $this->location->setFields($s['location'] as nonnull);
+      $this->location = Vec\map($s['location'], ($v) ==> { $o = new \google\protobuf\SourceCodeInfo_Location(); $o->setFields($v); return $o; });
     }
   }
 
   public function getNonDefaultFields(): SourceCodeInfoFields {
     $s = shape();
-    if (!C\is_empty($this->location)) $s['location'] = $this->location;
+    if (!C\is_empty($this->location)) $s['location'] = Vec\map($this->location, ($v) ==> $v->getNonDefaultFields());
     return $s;
   }
 
@@ -4565,14 +4539,13 @@ class GeneratedCodeInfo implements \Protobuf\Message {
 
   public function setFields(GeneratedCodeInfoFields $s = shape()): void {
     if (Shapes::keyExists($s, 'annotation')) {
-      if ($this->annotation is null) $this->annotation = new \google\protobuf\GeneratedCodeInfo_Annotation();
-      $this->annotation->setFields($s['annotation'] as nonnull);
+      $this->annotation = Vec\map($s['annotation'], ($v) ==> { $o = new \google\protobuf\GeneratedCodeInfo_Annotation(); $o->setFields($v); return $o; });
     }
   }
 
   public function getNonDefaultFields(): GeneratedCodeInfoFields {
     $s = shape();
-    if (!C\is_empty($this->annotation)) $s['annotation'] = $this->annotation;
+    if (!C\is_empty($this->annotation)) $s['annotation'] = Vec\map($this->annotation, ($v) ==> $v->getNonDefaultFields());
     return $s;
   }
 

--- a/generated/google/protobuf/descriptor_proto.php
+++ b/generated/google/protobuf/descriptor_proto.php
@@ -105,8 +105,8 @@ type FileDescriptorProtoFields = shape (
   ?'enum_type' => vec<\google\protobuf\EnumDescriptorProtoFields>,
   ?'service' => vec<\google\protobuf\ServiceDescriptorProtoFields>,
   ?'extension' => vec<\google\protobuf\FieldDescriptorProtoFields>,
-  ?'options' => ?\google\protobuf\FileOptionsFields,
-  ?'source_code_info' => ?\google\protobuf\SourceCodeInfoFields,
+  ?'options' => \google\protobuf\FileOptionsFields,
+  ?'source_code_info' => \google\protobuf\SourceCodeInfoFields,
   ?'syntax' => string,
 );
 class FileDescriptorProto implements \Protobuf\Message {
@@ -173,11 +173,11 @@ class FileDescriptorProto implements \Protobuf\Message {
     }
     if (Shapes::keyExists($s, 'options')) {
       if ($this->options is null) $this->options = new \google\protobuf\FileOptions();
-      $this->options->setFields($s['options'] as nonnull);
+      $this->options->setFields($s['options']);
     }
     if (Shapes::keyExists($s, 'source_code_info')) {
       if ($this->source_code_info is null) $this->source_code_info = new \google\protobuf\SourceCodeInfo();
-      $this->source_code_info->setFields($s['source_code_info'] as nonnull);
+      $this->source_code_info->setFields($s['source_code_info']);
     }
     if (Shapes::keyExists($s, 'syntax')) $this->syntax = $s['syntax'];
   }
@@ -472,7 +472,7 @@ class FileDescriptorProto implements \Protobuf\Message {
 type DescriptorProto_ExtensionRangeFields = shape (
   ?'start' => int,
   ?'end' => int,
-  ?'options' => ?\google\protobuf\ExtensionRangeOptionsFields,
+  ?'options' => \google\protobuf\ExtensionRangeOptionsFields,
 );
 class DescriptorProto_ExtensionRange implements \Protobuf\Message {
   public int $start;
@@ -496,7 +496,7 @@ class DescriptorProto_ExtensionRange implements \Protobuf\Message {
     if (Shapes::keyExists($s, 'end')) $this->end = $s['end'];
     if (Shapes::keyExists($s, 'options')) {
       if ($this->options is null) $this->options = new \google\protobuf\ExtensionRangeOptions();
-      $this->options->setFields($s['options'] as nonnull);
+      $this->options->setFields($s['options']);
     }
   }
 
@@ -700,7 +700,7 @@ type DescriptorProtoFields = shape (
   ?'enum_type' => vec<\google\protobuf\EnumDescriptorProtoFields>,
   ?'extension_range' => vec<\google\protobuf\DescriptorProto_ExtensionRangeFields>,
   ?'oneof_decl' => vec<\google\protobuf\OneofDescriptorProtoFields>,
-  ?'options' => ?\google\protobuf\MessageOptionsFields,
+  ?'options' => \google\protobuf\MessageOptionsFields,
   ?'reserved_range' => vec<\google\protobuf\DescriptorProto_ReservedRangeFields>,
   ?'reserved_name' => vec<string>,
 );
@@ -764,7 +764,7 @@ class DescriptorProto implements \Protobuf\Message {
     }
     if (Shapes::keyExists($s, 'options')) {
       if ($this->options is null) $this->options = new \google\protobuf\MessageOptions();
-      $this->options->setFields($s['options'] as nonnull);
+      $this->options->setFields($s['options']);
     }
     if (Shapes::keyExists($s, 'reserved_range')) {
       $this->reserved_range = Vec\map($s['reserved_range'], ($v) ==> { $o = new \google\protobuf\DescriptorProto_ReservedRange(); $o->setFields($v); return $o; });
@@ -1240,7 +1240,7 @@ type FieldDescriptorProtoFields = shape (
   ?'default_value' => string,
   ?'oneof_index' => int,
   ?'json_name' => string,
-  ?'options' => ?\google\protobuf\FieldOptionsFields,
+  ?'options' => \google\protobuf\FieldOptionsFields,
   ?'proto3_optional' => bool,
 );
 class FieldDescriptorProto implements \Protobuf\Message {
@@ -1296,7 +1296,7 @@ class FieldDescriptorProto implements \Protobuf\Message {
     if (Shapes::keyExists($s, 'json_name')) $this->json_name = $s['json_name'];
     if (Shapes::keyExists($s, 'options')) {
       if ($this->options is null) $this->options = new \google\protobuf\FieldOptions();
-      $this->options->setFields($s['options'] as nonnull);
+      $this->options->setFields($s['options']);
     }
     if (Shapes::keyExists($s, 'proto3_optional')) $this->proto3_optional = $s['proto3_optional'];
   }
@@ -1503,7 +1503,7 @@ class FieldDescriptorProto implements \Protobuf\Message {
 
 type OneofDescriptorProtoFields = shape (
   ?'name' => string,
-  ?'options' => ?\google\protobuf\OneofOptionsFields,
+  ?'options' => \google\protobuf\OneofOptionsFields,
 );
 class OneofDescriptorProto implements \Protobuf\Message {
   public string $name;
@@ -1523,7 +1523,7 @@ class OneofDescriptorProto implements \Protobuf\Message {
     if (Shapes::keyExists($s, 'name')) $this->name = $s['name'];
     if (Shapes::keyExists($s, 'options')) {
       if ($this->options is null) $this->options = new \google\protobuf\OneofOptions();
-      $this->options->setFields($s['options'] as nonnull);
+      $this->options->setFields($s['options']);
     }
   }
 
@@ -1709,7 +1709,7 @@ class EnumDescriptorProto_EnumReservedRange implements \Protobuf\Message {
 type EnumDescriptorProtoFields = shape (
   ?'name' => string,
   ?'value' => vec<\google\protobuf\EnumValueDescriptorProtoFields>,
-  ?'options' => ?\google\protobuf\EnumOptionsFields,
+  ?'options' => \google\protobuf\EnumOptionsFields,
   ?'reserved_range' => vec<\google\protobuf\EnumDescriptorProto_EnumReservedRangeFields>,
   ?'reserved_name' => vec<string>,
 );
@@ -1743,7 +1743,7 @@ class EnumDescriptorProto implements \Protobuf\Message {
     }
     if (Shapes::keyExists($s, 'options')) {
       if ($this->options is null) $this->options = new \google\protobuf\EnumOptions();
-      $this->options->setFields($s['options'] as nonnull);
+      $this->options->setFields($s['options']);
     }
     if (Shapes::keyExists($s, 'reserved_range')) {
       $this->reserved_range = Vec\map($s['reserved_range'], ($v) ==> { $o = new \google\protobuf\EnumDescriptorProto_EnumReservedRange(); $o->setFields($v); return $o; });
@@ -1900,7 +1900,7 @@ class EnumDescriptorProto implements \Protobuf\Message {
 type EnumValueDescriptorProtoFields = shape (
   ?'name' => string,
   ?'number' => int,
-  ?'options' => ?\google\protobuf\EnumValueOptionsFields,
+  ?'options' => \google\protobuf\EnumValueOptionsFields,
 );
 class EnumValueDescriptorProto implements \Protobuf\Message {
   public string $name;
@@ -1924,7 +1924,7 @@ class EnumValueDescriptorProto implements \Protobuf\Message {
     if (Shapes::keyExists($s, 'number')) $this->number = $s['number'];
     if (Shapes::keyExists($s, 'options')) {
       if ($this->options is null) $this->options = new \google\protobuf\EnumValueOptions();
-      $this->options->setFields($s['options'] as nonnull);
+      $this->options->setFields($s['options']);
     }
   }
 
@@ -2027,7 +2027,7 @@ class EnumValueDescriptorProto implements \Protobuf\Message {
 type ServiceDescriptorProtoFields = shape (
   ?'name' => string,
   ?'method' => vec<\google\protobuf\MethodDescriptorProtoFields>,
-  ?'options' => ?\google\protobuf\ServiceOptionsFields,
+  ?'options' => \google\protobuf\ServiceOptionsFields,
 );
 class ServiceDescriptorProto implements \Protobuf\Message {
   public string $name;
@@ -2053,7 +2053,7 @@ class ServiceDescriptorProto implements \Protobuf\Message {
     }
     if (Shapes::keyExists($s, 'options')) {
       if ($this->options is null) $this->options = new \google\protobuf\ServiceOptions();
-      $this->options->setFields($s['options'] as nonnull);
+      $this->options->setFields($s['options']);
     }
   }
 
@@ -2168,7 +2168,7 @@ type MethodDescriptorProtoFields = shape (
   ?'name' => string,
   ?'input_type' => string,
   ?'output_type' => string,
-  ?'options' => ?\google\protobuf\MethodOptionsFields,
+  ?'options' => \google\protobuf\MethodOptionsFields,
   ?'client_streaming' => bool,
   ?'server_streaming' => bool,
 );
@@ -2204,7 +2204,7 @@ class MethodDescriptorProto implements \Protobuf\Message {
     if (Shapes::keyExists($s, 'output_type')) $this->output_type = $s['output_type'];
     if (Shapes::keyExists($s, 'options')) {
       if ($this->options is null) $this->options = new \google\protobuf\MethodOptions();
-      $this->options->setFields($s['options'] as nonnull);
+      $this->options->setFields($s['options']);
     }
     if (Shapes::keyExists($s, 'client_streaming')) $this->client_streaming = $s['client_streaming'];
     if (Shapes::keyExists($s, 'server_streaming')) $this->server_streaming = $s['server_streaming'];

--- a/generated/google/protobuf/struct_proto.php
+++ b/generated/google/protobuf/struct_proto.php
@@ -55,6 +55,7 @@ class Struct_FieldsEntry implements \Protobuf\Message {
   public function getNonDefaultFields(): Struct_FieldsEntryFields {
     $s = shape();
     if ($this->key !== '') $s['key'] = $this->key;
+    if ($this->value is nonnull) $s['value'] = $this->value->getNonDefaultFields();
     return $s;
   }
 

--- a/generated/google/protobuf/struct_proto.php
+++ b/generated/google/protobuf/struct_proto.php
@@ -28,7 +28,7 @@ abstract class NullValue {
 
 type Struct_FieldsEntryFields = shape (
   ?'key' => string,
-  ?'value' => ?\google\protobuf\ValueFields,
+  ?'value' => \google\protobuf\ValueFields,
 );
 class Struct_FieldsEntry implements \Protobuf\Message {
   public string $key;
@@ -48,7 +48,7 @@ class Struct_FieldsEntry implements \Protobuf\Message {
     if (Shapes::keyExists($s, 'key')) $this->key = $s['key'];
     if (Shapes::keyExists($s, 'value')) {
       if ($this->value is null) $this->value = new \google\protobuf\Value();
-      $this->value->setFields($s['value'] as nonnull);
+      $this->value->setFields($s['value']);
     }
   }
 

--- a/generated/google/protobuf/struct_proto.php
+++ b/generated/google/protobuf/struct_proto.php
@@ -521,14 +521,13 @@ class ListValue implements \Protobuf\Message {
 
   public function setFields(ListValueFields $s = shape()): void {
     if (Shapes::keyExists($s, 'values')) {
-      if ($this->values is null) $this->values = new \google\protobuf\Value();
-      $this->values->setFields($s['values'] as nonnull);
+      $this->values = Vec\map($s['values'], ($v) ==> { $o = new \google\protobuf\Value(); $o->setFields($v); return $o; });
     }
   }
 
   public function getNonDefaultFields(): ListValueFields {
     $s = shape();
-    if (!C\is_empty($this->values)) $s['values'] = $this->values;
+    if (!C\is_empty($this->values)) $s['values'] = Vec\map($this->values, ($v) ==> $v->getNonDefaultFields());
     return $s;
   }
 

--- a/generated/google/protobuf/test_messages_proto2_proto.php
+++ b/generated/google/protobuf/test_messages_proto2_proto.php
@@ -3053,12 +3053,10 @@ class TestAllTypesProto2 implements \Protobuf\Message {
     if (Shapes::keyExists($s, 'repeated_string')) $this->repeated_string = $s['repeated_string'];
     if (Shapes::keyExists($s, 'repeated_bytes')) $this->repeated_bytes = $s['repeated_bytes'];
     if (Shapes::keyExists($s, 'repeated_nested_message')) {
-      if ($this->repeated_nested_message is null) $this->repeated_nested_message = new \protobuf_test_messages\proto2\TestAllTypesProto2_NestedMessage();
-      $this->repeated_nested_message->setFields($s['repeated_nested_message'] as nonnull);
+      $this->repeated_nested_message = Vec\map($s['repeated_nested_message'], ($v) ==> { $o = new \protobuf_test_messages\proto2\TestAllTypesProto2_NestedMessage(); $o->setFields($v); return $o; });
     }
     if (Shapes::keyExists($s, 'repeated_foreign_message')) {
-      if ($this->repeated_foreign_message is null) $this->repeated_foreign_message = new \protobuf_test_messages\proto2\ForeignMessageProto2();
-      $this->repeated_foreign_message->setFields($s['repeated_foreign_message'] as nonnull);
+      $this->repeated_foreign_message = Vec\map($s['repeated_foreign_message'], ($v) ==> { $o = new \protobuf_test_messages\proto2\ForeignMessageProto2(); $o->setFields($v); return $o; });
     }
     if (Shapes::keyExists($s, 'repeated_nested_enum')) $this->repeated_nested_enum = $s['repeated_nested_enum'];
     if (Shapes::keyExists($s, 'repeated_foreign_enum')) $this->repeated_foreign_enum = $s['repeated_foreign_enum'];
@@ -3172,8 +3170,8 @@ class TestAllTypesProto2 implements \Protobuf\Message {
     if (!C\is_empty($this->repeated_bool)) $s['repeated_bool'] = $this->repeated_bool;
     if (!C\is_empty($this->repeated_string)) $s['repeated_string'] = $this->repeated_string;
     if (!C\is_empty($this->repeated_bytes)) $s['repeated_bytes'] = $this->repeated_bytes;
-    if (!C\is_empty($this->repeated_nested_message)) $s['repeated_nested_message'] = $this->repeated_nested_message;
-    if (!C\is_empty($this->repeated_foreign_message)) $s['repeated_foreign_message'] = $this->repeated_foreign_message;
+    if (!C\is_empty($this->repeated_nested_message)) $s['repeated_nested_message'] = Vec\map($this->repeated_nested_message, ($v) ==> $v->getNonDefaultFields());
+    if (!C\is_empty($this->repeated_foreign_message)) $s['repeated_foreign_message'] = Vec\map($this->repeated_foreign_message, ($v) ==> $v->getNonDefaultFields());
     if (!C\is_empty($this->repeated_nested_enum)) $s['repeated_nested_enum'] = $this->repeated_nested_enum;
     if (!C\is_empty($this->repeated_foreign_enum)) $s['repeated_foreign_enum'] = $this->repeated_foreign_enum;
     if (!C\is_empty($this->repeated_string_piece)) $s['repeated_string_piece'] = $this->repeated_string_piece;

--- a/generated/google/protobuf/test_messages_proto2_proto.php
+++ b/generated/google/protobuf/test_messages_proto2_proto.php
@@ -316,6 +316,7 @@ class TestAllTypesProto2_NestedMessage implements \Protobuf\Message {
   public function getNonDefaultFields(): TestAllTypesProto2_NestedMessageFields {
     $s = shape();
     if ($this->a !== 0) $s['a'] = $this->a;
+    if ($this->corecursive is nonnull) $s['corecursive'] = $this->corecursive->getNonDefaultFields();
     return $s;
   }
 
@@ -1864,6 +1865,7 @@ class TestAllTypesProto2_MapStringNestedMessageEntry implements \Protobuf\Messag
   public function getNonDefaultFields(): TestAllTypesProto2_MapStringNestedMessageEntryFields {
     $s = shape();
     if ($this->key !== '') $s['key'] = $this->key;
+    if ($this->value is nonnull) $s['value'] = $this->value->getNonDefaultFields();
     return $s;
   }
 
@@ -1972,6 +1974,7 @@ class TestAllTypesProto2_MapStringForeignMessageEntry implements \Protobuf\Messa
   public function getNonDefaultFields(): TestAllTypesProto2_MapStringForeignMessageEntryFields {
     $s = shape();
     if ($this->key !== '') $s['key'] = $this->key;
+    if ($this->value is nonnull) $s['value'] = $this->value->getNonDefaultFields();
     return $s;
   }
 
@@ -3151,10 +3154,13 @@ class TestAllTypesProto2 implements \Protobuf\Message {
     if ($this->optional_bool !== false) $s['optional_bool'] = $this->optional_bool;
     if ($this->optional_string !== '') $s['optional_string'] = $this->optional_string;
     if ($this->optional_bytes !== '') $s['optional_bytes'] = $this->optional_bytes;
+    if ($this->optional_nested_message is nonnull) $s['optional_nested_message'] = $this->optional_nested_message->getNonDefaultFields();
+    if ($this->optional_foreign_message is nonnull) $s['optional_foreign_message'] = $this->optional_foreign_message->getNonDefaultFields();
     if ($this->optional_nested_enum !== \protobuf_test_messages\proto2\TestAllTypesProto2_NestedEnum::FromInt(0)) $s['optional_nested_enum'] = $this->optional_nested_enum;
     if ($this->optional_foreign_enum !== \protobuf_test_messages\proto2\ForeignEnumProto2::FromInt(0)) $s['optional_foreign_enum'] = $this->optional_foreign_enum;
     if ($this->optional_string_piece !== '') $s['optional_string_piece'] = $this->optional_string_piece;
     if ($this->optional_cord !== '') $s['optional_cord'] = $this->optional_cord;
+    if ($this->recursive_message is nonnull) $s['recursive_message'] = $this->recursive_message->getNonDefaultFields();
     if (!C\is_empty($this->repeated_int32)) $s['repeated_int32'] = $this->repeated_int32;
     if (!C\is_empty($this->repeated_int64)) $s['repeated_int64'] = $this->repeated_int64;
     if (!C\is_empty($this->repeated_uint32)) $s['repeated_uint32'] = $this->repeated_uint32;
@@ -3223,6 +3229,7 @@ class TestAllTypesProto2 implements \Protobuf\Message {
     if (!C\is_empty($this->map_string_foreign_message)) $s['map_string_foreign_message'] = Dict\map($this->map_string_foreign_message, ($v) ==> $v->getNonDefaultFields());
     if (!C\is_empty($this->map_string_nested_enum)) $s['map_string_nested_enum'] = $this->map_string_nested_enum;
     if (!C\is_empty($this->map_string_foreign_enum)) $s['map_string_foreign_enum'] = $this->map_string_foreign_enum;
+    if ($this->data is nonnull) $s['data'] = $this->data->getNonDefaultFields();
     if ($this->fieldname1 !== 0) $s['fieldname1'] = $this->fieldname1;
     if ($this->field_name2 !== 0) $s['field_name2'] = $this->field_name2;
     if ($this->_field_name3 !== 0) $s['_field_name3'] = $this->_field_name3;
@@ -5538,6 +5545,8 @@ class UnknownToTestAllTypes implements \Protobuf\Message {
     $s = shape();
     if ($this->optional_int32 !== 0) $s['optional_int32'] = $this->optional_int32;
     if ($this->optional_string !== '') $s['optional_string'] = $this->optional_string;
+    if ($this->nested_message is nonnull) $s['nested_message'] = $this->nested_message->getNonDefaultFields();
+    if ($this->optionalgroup is nonnull) $s['optionalgroup'] = $this->optionalgroup->getNonDefaultFields();
     if ($this->optional_bool !== false) $s['optional_bool'] = $this->optional_bool;
     if (!C\is_empty($this->repeated_int32)) $s['repeated_int32'] = $this->repeated_int32;
     return $s;

--- a/generated/google/protobuf/test_messages_proto2_proto.php
+++ b/generated/google/protobuf/test_messages_proto2_proto.php
@@ -289,7 +289,7 @@ class TestAllTypesProto2_oneof_field_oneof_enum implements TestAllTypesProto2_on
 
 type TestAllTypesProto2_NestedMessageFields = shape (
   ?'a' => int,
-  ?'corecursive' => ?\protobuf_test_messages\proto2\TestAllTypesProto2Fields,
+  ?'corecursive' => \protobuf_test_messages\proto2\TestAllTypesProto2Fields,
 );
 class TestAllTypesProto2_NestedMessage implements \Protobuf\Message {
   public int $a;
@@ -309,7 +309,7 @@ class TestAllTypesProto2_NestedMessage implements \Protobuf\Message {
     if (Shapes::keyExists($s, 'a')) $this->a = $s['a'];
     if (Shapes::keyExists($s, 'corecursive')) {
       if ($this->corecursive is null) $this->corecursive = new \protobuf_test_messages\proto2\TestAllTypesProto2();
-      $this->corecursive->setFields($s['corecursive'] as nonnull);
+      $this->corecursive->setFields($s['corecursive']);
     }
   }
 
@@ -1838,7 +1838,7 @@ class TestAllTypesProto2_MapStringBytesEntry implements \Protobuf\Message {
 
 type TestAllTypesProto2_MapStringNestedMessageEntryFields = shape (
   ?'key' => string,
-  ?'value' => ?\protobuf_test_messages\proto2\TestAllTypesProto2_NestedMessageFields,
+  ?'value' => \protobuf_test_messages\proto2\TestAllTypesProto2_NestedMessageFields,
 );
 class TestAllTypesProto2_MapStringNestedMessageEntry implements \Protobuf\Message {
   public string $key;
@@ -1858,7 +1858,7 @@ class TestAllTypesProto2_MapStringNestedMessageEntry implements \Protobuf\Messag
     if (Shapes::keyExists($s, 'key')) $this->key = $s['key'];
     if (Shapes::keyExists($s, 'value')) {
       if ($this->value is null) $this->value = new \protobuf_test_messages\proto2\TestAllTypesProto2_NestedMessage();
-      $this->value->setFields($s['value'] as nonnull);
+      $this->value->setFields($s['value']);
     }
   }
 
@@ -1947,7 +1947,7 @@ class TestAllTypesProto2_MapStringNestedMessageEntry implements \Protobuf\Messag
 
 type TestAllTypesProto2_MapStringForeignMessageEntryFields = shape (
   ?'key' => string,
-  ?'value' => ?\protobuf_test_messages\proto2\ForeignMessageProto2Fields,
+  ?'value' => \protobuf_test_messages\proto2\ForeignMessageProto2Fields,
 );
 class TestAllTypesProto2_MapStringForeignMessageEntry implements \Protobuf\Message {
   public string $key;
@@ -1967,7 +1967,7 @@ class TestAllTypesProto2_MapStringForeignMessageEntry implements \Protobuf\Messa
     if (Shapes::keyExists($s, 'key')) $this->key = $s['key'];
     if (Shapes::keyExists($s, 'value')) {
       if ($this->value is null) $this->value = new \protobuf_test_messages\proto2\ForeignMessageProto2();
-      $this->value->setFields($s['value'] as nonnull);
+      $this->value->setFields($s['value']);
     }
   }
 
@@ -2574,13 +2574,13 @@ type TestAllTypesProto2Fields = shape (
   ?'optional_bool' => bool,
   ?'optional_string' => string,
   ?'optional_bytes' => string,
-  ?'optional_nested_message' => ?\protobuf_test_messages\proto2\TestAllTypesProto2_NestedMessageFields,
-  ?'optional_foreign_message' => ?\protobuf_test_messages\proto2\ForeignMessageProto2Fields,
+  ?'optional_nested_message' => \protobuf_test_messages\proto2\TestAllTypesProto2_NestedMessageFields,
+  ?'optional_foreign_message' => \protobuf_test_messages\proto2\ForeignMessageProto2Fields,
   ?'optional_nested_enum' => \protobuf_test_messages\proto2\TestAllTypesProto2_NestedEnum_enum_t,
   ?'optional_foreign_enum' => \protobuf_test_messages\proto2\ForeignEnumProto2_enum_t,
   ?'optional_string_piece' => string,
   ?'optional_cord' => string,
-  ?'recursive_message' => ?\protobuf_test_messages\proto2\TestAllTypesProto2Fields,
+  ?'recursive_message' => \protobuf_test_messages\proto2\TestAllTypesProto2Fields,
   ?'repeated_int32' => vec<int>,
   ?'repeated_int64' => vec<int>,
   ?'repeated_uint32' => vec<int>,
@@ -2649,7 +2649,7 @@ type TestAllTypesProto2Fields = shape (
   ?'map_string_foreign_message' => dict<string, \protobuf_test_messages\proto2\ForeignMessageProto2Fields>,
   ?'map_string_nested_enum' => dict<string, \protobuf_test_messages\proto2\TestAllTypesProto2_NestedEnum_enum_t>,
   ?'map_string_foreign_enum' => dict<string, \protobuf_test_messages\proto2\ForeignEnumProto2_enum_t>,
-  ?'data' => ?\protobuf_test_messages\proto2\TestAllTypesProto2_DataFields,
+  ?'data' => \protobuf_test_messages\proto2\TestAllTypesProto2_DataFields,
   ?'fieldname1' => int,
   ?'field_name2' => int,
   ?'_field_name3' => int,
@@ -3026,11 +3026,11 @@ class TestAllTypesProto2 implements \Protobuf\Message {
     if (Shapes::keyExists($s, 'optional_bytes')) $this->optional_bytes = $s['optional_bytes'];
     if (Shapes::keyExists($s, 'optional_nested_message')) {
       if ($this->optional_nested_message is null) $this->optional_nested_message = new \protobuf_test_messages\proto2\TestAllTypesProto2_NestedMessage();
-      $this->optional_nested_message->setFields($s['optional_nested_message'] as nonnull);
+      $this->optional_nested_message->setFields($s['optional_nested_message']);
     }
     if (Shapes::keyExists($s, 'optional_foreign_message')) {
       if ($this->optional_foreign_message is null) $this->optional_foreign_message = new \protobuf_test_messages\proto2\ForeignMessageProto2();
-      $this->optional_foreign_message->setFields($s['optional_foreign_message'] as nonnull);
+      $this->optional_foreign_message->setFields($s['optional_foreign_message']);
     }
     if (Shapes::keyExists($s, 'optional_nested_enum')) $this->optional_nested_enum = $s['optional_nested_enum'];
     if (Shapes::keyExists($s, 'optional_foreign_enum')) $this->optional_foreign_enum = $s['optional_foreign_enum'];
@@ -3038,7 +3038,7 @@ class TestAllTypesProto2 implements \Protobuf\Message {
     if (Shapes::keyExists($s, 'optional_cord')) $this->optional_cord = $s['optional_cord'];
     if (Shapes::keyExists($s, 'recursive_message')) {
       if ($this->recursive_message is null) $this->recursive_message = new \protobuf_test_messages\proto2\TestAllTypesProto2();
-      $this->recursive_message->setFields($s['recursive_message'] as nonnull);
+      $this->recursive_message->setFields($s['recursive_message']);
     }
     if (Shapes::keyExists($s, 'repeated_int32')) $this->repeated_int32 = $s['repeated_int32'];
     if (Shapes::keyExists($s, 'repeated_int64')) $this->repeated_int64 = $s['repeated_int64'];
@@ -3114,7 +3114,7 @@ class TestAllTypesProto2 implements \Protobuf\Message {
     if (Shapes::keyExists($s, 'map_string_foreign_enum')) $this->map_string_foreign_enum = $s['map_string_foreign_enum'];
     if (Shapes::keyExists($s, 'data')) {
       if ($this->data is null) $this->data = new \protobuf_test_messages\proto2\TestAllTypesProto2_Data();
-      $this->data->setFields($s['data'] as nonnull);
+      $this->data->setFields($s['data']);
     }
     if (Shapes::keyExists($s, 'fieldname1')) $this->fieldname1 = $s['fieldname1'];
     if (Shapes::keyExists($s, 'field_name2')) $this->field_name2 = $s['field_name2'];
@@ -5495,8 +5495,8 @@ class UnknownToTestAllTypes_OptionalGroup implements \Protobuf\Message {
 type UnknownToTestAllTypesFields = shape (
   ?'optional_int32' => int,
   ?'optional_string' => string,
-  ?'nested_message' => ?\protobuf_test_messages\proto2\ForeignMessageProto2Fields,
-  ?'optionalgroup' => ?\protobuf_test_messages\proto2\UnknownToTestAllTypes_OptionalGroupFields,
+  ?'nested_message' => \protobuf_test_messages\proto2\ForeignMessageProto2Fields,
+  ?'optionalgroup' => \protobuf_test_messages\proto2\UnknownToTestAllTypes_OptionalGroupFields,
   ?'optional_bool' => bool,
   ?'repeated_int32' => vec<int>,
 );
@@ -5531,11 +5531,11 @@ class UnknownToTestAllTypes implements \Protobuf\Message {
     if (Shapes::keyExists($s, 'optional_string')) $this->optional_string = $s['optional_string'];
     if (Shapes::keyExists($s, 'nested_message')) {
       if ($this->nested_message is null) $this->nested_message = new \protobuf_test_messages\proto2\ForeignMessageProto2();
-      $this->nested_message->setFields($s['nested_message'] as nonnull);
+      $this->nested_message->setFields($s['nested_message']);
     }
     if (Shapes::keyExists($s, 'optionalgroup')) {
       if ($this->optionalgroup is null) $this->optionalgroup = new \protobuf_test_messages\proto2\UnknownToTestAllTypes_OptionalGroup();
-      $this->optionalgroup->setFields($s['optionalgroup'] as nonnull);
+      $this->optionalgroup->setFields($s['optionalgroup']);
     }
     if (Shapes::keyExists($s, 'optional_bool')) $this->optional_bool = $s['optional_bool'];
     if (Shapes::keyExists($s, 'repeated_int32')) $this->repeated_int32 = $s['repeated_int32'];

--- a/generated/google/protobuf/test_messages_proto3_proto.php
+++ b/generated/google/protobuf/test_messages_proto3_proto.php
@@ -375,6 +375,7 @@ class TestAllTypesProto3_NestedMessage implements \Protobuf\Message {
   public function getNonDefaultFields(): TestAllTypesProto3_NestedMessageFields {
     $s = shape();
     if ($this->a !== 0) $s['a'] = $this->a;
+    if ($this->corecursive is nonnull) $s['corecursive'] = $this->corecursive->getNonDefaultFields();
     return $s;
   }
 
@@ -1923,6 +1924,7 @@ class TestAllTypesProto3_MapStringNestedMessageEntry implements \Protobuf\Messag
   public function getNonDefaultFields(): TestAllTypesProto3_MapStringNestedMessageEntryFields {
     $s = shape();
     if ($this->key !== '') $s['key'] = $this->key;
+    if ($this->value is nonnull) $s['value'] = $this->value->getNonDefaultFields();
     return $s;
   }
 
@@ -2031,6 +2033,7 @@ class TestAllTypesProto3_MapStringForeignMessageEntry implements \Protobuf\Messa
   public function getNonDefaultFields(): TestAllTypesProto3_MapStringForeignMessageEntryFields {
     $s = shape();
     if ($this->key !== '') $s['key'] = $this->key;
+    if ($this->value is nonnull) $s['value'] = $this->value->getNonDefaultFields();
     return $s;
   }
 
@@ -3132,11 +3135,14 @@ class TestAllTypesProto3 implements \Protobuf\Message {
     if ($this->optional_bool !== false) $s['optional_bool'] = $this->optional_bool;
     if ($this->optional_string !== '') $s['optional_string'] = $this->optional_string;
     if ($this->optional_bytes !== '') $s['optional_bytes'] = $this->optional_bytes;
+    if ($this->optional_nested_message is nonnull) $s['optional_nested_message'] = $this->optional_nested_message->getNonDefaultFields();
+    if ($this->optional_foreign_message is nonnull) $s['optional_foreign_message'] = $this->optional_foreign_message->getNonDefaultFields();
     if ($this->optional_nested_enum !== \protobuf_test_messages\proto3\TestAllTypesProto3_NestedEnum::FromInt(0)) $s['optional_nested_enum'] = $this->optional_nested_enum;
     if ($this->optional_foreign_enum !== \protobuf_test_messages\proto3\ForeignEnum::FromInt(0)) $s['optional_foreign_enum'] = $this->optional_foreign_enum;
     if ($this->optional_aliased_enum !== \protobuf_test_messages\proto3\TestAllTypesProto3_AliasedEnum::FromInt(0)) $s['optional_aliased_enum'] = $this->optional_aliased_enum;
     if ($this->optional_string_piece !== '') $s['optional_string_piece'] = $this->optional_string_piece;
     if ($this->optional_cord !== '') $s['optional_cord'] = $this->optional_cord;
+    if ($this->recursive_message is nonnull) $s['recursive_message'] = $this->recursive_message->getNonDefaultFields();
     if (!C\is_empty($this->repeated_int32)) $s['repeated_int32'] = $this->repeated_int32;
     if (!C\is_empty($this->repeated_int64)) $s['repeated_int64'] = $this->repeated_int64;
     if (!C\is_empty($this->repeated_uint32)) $s['repeated_uint32'] = $this->repeated_uint32;
@@ -3205,6 +3211,15 @@ class TestAllTypesProto3 implements \Protobuf\Message {
     if (!C\is_empty($this->map_string_foreign_message)) $s['map_string_foreign_message'] = Dict\map($this->map_string_foreign_message, ($v) ==> $v->getNonDefaultFields());
     if (!C\is_empty($this->map_string_nested_enum)) $s['map_string_nested_enum'] = $this->map_string_nested_enum;
     if (!C\is_empty($this->map_string_foreign_enum)) $s['map_string_foreign_enum'] = $this->map_string_foreign_enum;
+    if ($this->optional_bool_wrapper is nonnull) $s['optional_bool_wrapper'] = $this->optional_bool_wrapper->getNonDefaultFields();
+    if ($this->optional_int32_wrapper is nonnull) $s['optional_int32_wrapper'] = $this->optional_int32_wrapper->getNonDefaultFields();
+    if ($this->optional_int64_wrapper is nonnull) $s['optional_int64_wrapper'] = $this->optional_int64_wrapper->getNonDefaultFields();
+    if ($this->optional_uint32_wrapper is nonnull) $s['optional_uint32_wrapper'] = $this->optional_uint32_wrapper->getNonDefaultFields();
+    if ($this->optional_uint64_wrapper is nonnull) $s['optional_uint64_wrapper'] = $this->optional_uint64_wrapper->getNonDefaultFields();
+    if ($this->optional_float_wrapper is nonnull) $s['optional_float_wrapper'] = $this->optional_float_wrapper->getNonDefaultFields();
+    if ($this->optional_double_wrapper is nonnull) $s['optional_double_wrapper'] = $this->optional_double_wrapper->getNonDefaultFields();
+    if ($this->optional_string_wrapper is nonnull) $s['optional_string_wrapper'] = $this->optional_string_wrapper->getNonDefaultFields();
+    if ($this->optional_bytes_wrapper is nonnull) $s['optional_bytes_wrapper'] = $this->optional_bytes_wrapper->getNonDefaultFields();
     if (!C\is_empty($this->repeated_bool_wrapper)) $s['repeated_bool_wrapper'] = Vec\map($this->repeated_bool_wrapper, ($v) ==> $v->getNonDefaultFields());
     if (!C\is_empty($this->repeated_int32_wrapper)) $s['repeated_int32_wrapper'] = Vec\map($this->repeated_int32_wrapper, ($v) ==> $v->getNonDefaultFields());
     if (!C\is_empty($this->repeated_int64_wrapper)) $s['repeated_int64_wrapper'] = Vec\map($this->repeated_int64_wrapper, ($v) ==> $v->getNonDefaultFields());
@@ -3214,6 +3229,12 @@ class TestAllTypesProto3 implements \Protobuf\Message {
     if (!C\is_empty($this->repeated_double_wrapper)) $s['repeated_double_wrapper'] = Vec\map($this->repeated_double_wrapper, ($v) ==> $v->getNonDefaultFields());
     if (!C\is_empty($this->repeated_string_wrapper)) $s['repeated_string_wrapper'] = Vec\map($this->repeated_string_wrapper, ($v) ==> $v->getNonDefaultFields());
     if (!C\is_empty($this->repeated_bytes_wrapper)) $s['repeated_bytes_wrapper'] = Vec\map($this->repeated_bytes_wrapper, ($v) ==> $v->getNonDefaultFields());
+    if ($this->optional_duration is nonnull) $s['optional_duration'] = $this->optional_duration->getNonDefaultFields();
+    if ($this->optional_timestamp is nonnull) $s['optional_timestamp'] = $this->optional_timestamp->getNonDefaultFields();
+    if ($this->optional_field_mask is nonnull) $s['optional_field_mask'] = $this->optional_field_mask->getNonDefaultFields();
+    if ($this->optional_struct is nonnull) $s['optional_struct'] = $this->optional_struct->getNonDefaultFields();
+    if ($this->optional_any is nonnull) $s['optional_any'] = $this->optional_any->getNonDefaultFields();
+    if ($this->optional_value is nonnull) $s['optional_value'] = $this->optional_value->getNonDefaultFields();
     if ($this->optional_null_value !== \google\protobuf\NullValue::FromInt(0)) $s['optional_null_value'] = $this->optional_null_value;
     if (!C\is_empty($this->repeated_duration)) $s['repeated_duration'] = Vec\map($this->repeated_duration, ($v) ==> $v->getNonDefaultFields());
     if (!C\is_empty($this->repeated_timestamp)) $s['repeated_timestamp'] = Vec\map($this->repeated_timestamp, ($v) ==> $v->getNonDefaultFields());

--- a/generated/google/protobuf/test_messages_proto3_proto.php
+++ b/generated/google/protobuf/test_messages_proto3_proto.php
@@ -348,7 +348,7 @@ class TestAllTypesProto3_oneof_field_oneof_null_value implements TestAllTypesPro
 
 type TestAllTypesProto3_NestedMessageFields = shape (
   ?'a' => int,
-  ?'corecursive' => ?\protobuf_test_messages\proto3\TestAllTypesProto3Fields,
+  ?'corecursive' => \protobuf_test_messages\proto3\TestAllTypesProto3Fields,
 );
 class TestAllTypesProto3_NestedMessage implements \Protobuf\Message {
   public int $a;
@@ -368,7 +368,7 @@ class TestAllTypesProto3_NestedMessage implements \Protobuf\Message {
     if (Shapes::keyExists($s, 'a')) $this->a = $s['a'];
     if (Shapes::keyExists($s, 'corecursive')) {
       if ($this->corecursive is null) $this->corecursive = new \protobuf_test_messages\proto3\TestAllTypesProto3();
-      $this->corecursive->setFields($s['corecursive'] as nonnull);
+      $this->corecursive->setFields($s['corecursive']);
     }
   }
 
@@ -1897,7 +1897,7 @@ class TestAllTypesProto3_MapStringBytesEntry implements \Protobuf\Message {
 
 type TestAllTypesProto3_MapStringNestedMessageEntryFields = shape (
   ?'key' => string,
-  ?'value' => ?\protobuf_test_messages\proto3\TestAllTypesProto3_NestedMessageFields,
+  ?'value' => \protobuf_test_messages\proto3\TestAllTypesProto3_NestedMessageFields,
 );
 class TestAllTypesProto3_MapStringNestedMessageEntry implements \Protobuf\Message {
   public string $key;
@@ -1917,7 +1917,7 @@ class TestAllTypesProto3_MapStringNestedMessageEntry implements \Protobuf\Messag
     if (Shapes::keyExists($s, 'key')) $this->key = $s['key'];
     if (Shapes::keyExists($s, 'value')) {
       if ($this->value is null) $this->value = new \protobuf_test_messages\proto3\TestAllTypesProto3_NestedMessage();
-      $this->value->setFields($s['value'] as nonnull);
+      $this->value->setFields($s['value']);
     }
   }
 
@@ -2006,7 +2006,7 @@ class TestAllTypesProto3_MapStringNestedMessageEntry implements \Protobuf\Messag
 
 type TestAllTypesProto3_MapStringForeignMessageEntryFields = shape (
   ?'key' => string,
-  ?'value' => ?\protobuf_test_messages\proto3\ForeignMessageFields,
+  ?'value' => \protobuf_test_messages\proto3\ForeignMessageFields,
 );
 class TestAllTypesProto3_MapStringForeignMessageEntry implements \Protobuf\Message {
   public string $key;
@@ -2026,7 +2026,7 @@ class TestAllTypesProto3_MapStringForeignMessageEntry implements \Protobuf\Messa
     if (Shapes::keyExists($s, 'key')) $this->key = $s['key'];
     if (Shapes::keyExists($s, 'value')) {
       if ($this->value is null) $this->value = new \protobuf_test_messages\proto3\ForeignMessage();
-      $this->value->setFields($s['value'] as nonnull);
+      $this->value->setFields($s['value']);
     }
   }
 
@@ -2321,14 +2321,14 @@ type TestAllTypesProto3Fields = shape (
   ?'optional_bool' => bool,
   ?'optional_string' => string,
   ?'optional_bytes' => string,
-  ?'optional_nested_message' => ?\protobuf_test_messages\proto3\TestAllTypesProto3_NestedMessageFields,
-  ?'optional_foreign_message' => ?\protobuf_test_messages\proto3\ForeignMessageFields,
+  ?'optional_nested_message' => \protobuf_test_messages\proto3\TestAllTypesProto3_NestedMessageFields,
+  ?'optional_foreign_message' => \protobuf_test_messages\proto3\ForeignMessageFields,
   ?'optional_nested_enum' => \protobuf_test_messages\proto3\TestAllTypesProto3_NestedEnum_enum_t,
   ?'optional_foreign_enum' => \protobuf_test_messages\proto3\ForeignEnum_enum_t,
   ?'optional_aliased_enum' => \protobuf_test_messages\proto3\TestAllTypesProto3_AliasedEnum_enum_t,
   ?'optional_string_piece' => string,
   ?'optional_cord' => string,
-  ?'recursive_message' => ?\protobuf_test_messages\proto3\TestAllTypesProto3Fields,
+  ?'recursive_message' => \protobuf_test_messages\proto3\TestAllTypesProto3Fields,
   ?'repeated_int32' => vec<int>,
   ?'repeated_int64' => vec<int>,
   ?'repeated_uint32' => vec<int>,
@@ -2397,15 +2397,15 @@ type TestAllTypesProto3Fields = shape (
   ?'map_string_foreign_message' => dict<string, \protobuf_test_messages\proto3\ForeignMessageFields>,
   ?'map_string_nested_enum' => dict<string, \protobuf_test_messages\proto3\TestAllTypesProto3_NestedEnum_enum_t>,
   ?'map_string_foreign_enum' => dict<string, \protobuf_test_messages\proto3\ForeignEnum_enum_t>,
-  ?'optional_bool_wrapper' => ?\google\protobuf\BoolValueFields,
-  ?'optional_int32_wrapper' => ?\google\protobuf\Int32ValueFields,
-  ?'optional_int64_wrapper' => ?\google\protobuf\Int64ValueFields,
-  ?'optional_uint32_wrapper' => ?\google\protobuf\UInt32ValueFields,
-  ?'optional_uint64_wrapper' => ?\google\protobuf\UInt64ValueFields,
-  ?'optional_float_wrapper' => ?\google\protobuf\FloatValueFields,
-  ?'optional_double_wrapper' => ?\google\protobuf\DoubleValueFields,
-  ?'optional_string_wrapper' => ?\google\protobuf\StringValueFields,
-  ?'optional_bytes_wrapper' => ?\google\protobuf\BytesValueFields,
+  ?'optional_bool_wrapper' => \google\protobuf\BoolValueFields,
+  ?'optional_int32_wrapper' => \google\protobuf\Int32ValueFields,
+  ?'optional_int64_wrapper' => \google\protobuf\Int64ValueFields,
+  ?'optional_uint32_wrapper' => \google\protobuf\UInt32ValueFields,
+  ?'optional_uint64_wrapper' => \google\protobuf\UInt64ValueFields,
+  ?'optional_float_wrapper' => \google\protobuf\FloatValueFields,
+  ?'optional_double_wrapper' => \google\protobuf\DoubleValueFields,
+  ?'optional_string_wrapper' => \google\protobuf\StringValueFields,
+  ?'optional_bytes_wrapper' => \google\protobuf\BytesValueFields,
   ?'repeated_bool_wrapper' => vec<\google\protobuf\BoolValueFields>,
   ?'repeated_int32_wrapper' => vec<\google\protobuf\Int32ValueFields>,
   ?'repeated_int64_wrapper' => vec<\google\protobuf\Int64ValueFields>,
@@ -2415,12 +2415,12 @@ type TestAllTypesProto3Fields = shape (
   ?'repeated_double_wrapper' => vec<\google\protobuf\DoubleValueFields>,
   ?'repeated_string_wrapper' => vec<\google\protobuf\StringValueFields>,
   ?'repeated_bytes_wrapper' => vec<\google\protobuf\BytesValueFields>,
-  ?'optional_duration' => ?\google\protobuf\DurationFields,
-  ?'optional_timestamp' => ?\google\protobuf\TimestampFields,
-  ?'optional_field_mask' => ?\google\protobuf\FieldMaskFields,
-  ?'optional_struct' => ?\google\protobuf\StructFields,
-  ?'optional_any' => ?\google\protobuf\AnyFields,
-  ?'optional_value' => ?\google\protobuf\ValueFields,
+  ?'optional_duration' => \google\protobuf\DurationFields,
+  ?'optional_timestamp' => \google\protobuf\TimestampFields,
+  ?'optional_field_mask' => \google\protobuf\FieldMaskFields,
+  ?'optional_struct' => \google\protobuf\StructFields,
+  ?'optional_any' => \google\protobuf\AnyFields,
+  ?'optional_value' => \google\protobuf\ValueFields,
   ?'optional_null_value' => \google\protobuf\NullValue_enum_t,
   ?'repeated_duration' => vec<\google\protobuf\DurationFields>,
   ?'repeated_timestamp' => vec<\google\protobuf\TimestampFields>,
@@ -2901,11 +2901,11 @@ class TestAllTypesProto3 implements \Protobuf\Message {
     if (Shapes::keyExists($s, 'optional_bytes')) $this->optional_bytes = $s['optional_bytes'];
     if (Shapes::keyExists($s, 'optional_nested_message')) {
       if ($this->optional_nested_message is null) $this->optional_nested_message = new \protobuf_test_messages\proto3\TestAllTypesProto3_NestedMessage();
-      $this->optional_nested_message->setFields($s['optional_nested_message'] as nonnull);
+      $this->optional_nested_message->setFields($s['optional_nested_message']);
     }
     if (Shapes::keyExists($s, 'optional_foreign_message')) {
       if ($this->optional_foreign_message is null) $this->optional_foreign_message = new \protobuf_test_messages\proto3\ForeignMessage();
-      $this->optional_foreign_message->setFields($s['optional_foreign_message'] as nonnull);
+      $this->optional_foreign_message->setFields($s['optional_foreign_message']);
     }
     if (Shapes::keyExists($s, 'optional_nested_enum')) $this->optional_nested_enum = $s['optional_nested_enum'];
     if (Shapes::keyExists($s, 'optional_foreign_enum')) $this->optional_foreign_enum = $s['optional_foreign_enum'];
@@ -2914,7 +2914,7 @@ class TestAllTypesProto3 implements \Protobuf\Message {
     if (Shapes::keyExists($s, 'optional_cord')) $this->optional_cord = $s['optional_cord'];
     if (Shapes::keyExists($s, 'recursive_message')) {
       if ($this->recursive_message is null) $this->recursive_message = new \protobuf_test_messages\proto3\TestAllTypesProto3();
-      $this->recursive_message->setFields($s['recursive_message'] as nonnull);
+      $this->recursive_message->setFields($s['recursive_message']);
     }
     if (Shapes::keyExists($s, 'repeated_int32')) $this->repeated_int32 = $s['repeated_int32'];
     if (Shapes::keyExists($s, 'repeated_int64')) $this->repeated_int64 = $s['repeated_int64'];
@@ -2990,39 +2990,39 @@ class TestAllTypesProto3 implements \Protobuf\Message {
     if (Shapes::keyExists($s, 'map_string_foreign_enum')) $this->map_string_foreign_enum = $s['map_string_foreign_enum'];
     if (Shapes::keyExists($s, 'optional_bool_wrapper')) {
       if ($this->optional_bool_wrapper is null) $this->optional_bool_wrapper = new \google\protobuf\BoolValue();
-      $this->optional_bool_wrapper->setFields($s['optional_bool_wrapper'] as nonnull);
+      $this->optional_bool_wrapper->setFields($s['optional_bool_wrapper']);
     }
     if (Shapes::keyExists($s, 'optional_int32_wrapper')) {
       if ($this->optional_int32_wrapper is null) $this->optional_int32_wrapper = new \google\protobuf\Int32Value();
-      $this->optional_int32_wrapper->setFields($s['optional_int32_wrapper'] as nonnull);
+      $this->optional_int32_wrapper->setFields($s['optional_int32_wrapper']);
     }
     if (Shapes::keyExists($s, 'optional_int64_wrapper')) {
       if ($this->optional_int64_wrapper is null) $this->optional_int64_wrapper = new \google\protobuf\Int64Value();
-      $this->optional_int64_wrapper->setFields($s['optional_int64_wrapper'] as nonnull);
+      $this->optional_int64_wrapper->setFields($s['optional_int64_wrapper']);
     }
     if (Shapes::keyExists($s, 'optional_uint32_wrapper')) {
       if ($this->optional_uint32_wrapper is null) $this->optional_uint32_wrapper = new \google\protobuf\UInt32Value();
-      $this->optional_uint32_wrapper->setFields($s['optional_uint32_wrapper'] as nonnull);
+      $this->optional_uint32_wrapper->setFields($s['optional_uint32_wrapper']);
     }
     if (Shapes::keyExists($s, 'optional_uint64_wrapper')) {
       if ($this->optional_uint64_wrapper is null) $this->optional_uint64_wrapper = new \google\protobuf\UInt64Value();
-      $this->optional_uint64_wrapper->setFields($s['optional_uint64_wrapper'] as nonnull);
+      $this->optional_uint64_wrapper->setFields($s['optional_uint64_wrapper']);
     }
     if (Shapes::keyExists($s, 'optional_float_wrapper')) {
       if ($this->optional_float_wrapper is null) $this->optional_float_wrapper = new \google\protobuf\FloatValue();
-      $this->optional_float_wrapper->setFields($s['optional_float_wrapper'] as nonnull);
+      $this->optional_float_wrapper->setFields($s['optional_float_wrapper']);
     }
     if (Shapes::keyExists($s, 'optional_double_wrapper')) {
       if ($this->optional_double_wrapper is null) $this->optional_double_wrapper = new \google\protobuf\DoubleValue();
-      $this->optional_double_wrapper->setFields($s['optional_double_wrapper'] as nonnull);
+      $this->optional_double_wrapper->setFields($s['optional_double_wrapper']);
     }
     if (Shapes::keyExists($s, 'optional_string_wrapper')) {
       if ($this->optional_string_wrapper is null) $this->optional_string_wrapper = new \google\protobuf\StringValue();
-      $this->optional_string_wrapper->setFields($s['optional_string_wrapper'] as nonnull);
+      $this->optional_string_wrapper->setFields($s['optional_string_wrapper']);
     }
     if (Shapes::keyExists($s, 'optional_bytes_wrapper')) {
       if ($this->optional_bytes_wrapper is null) $this->optional_bytes_wrapper = new \google\protobuf\BytesValue();
-      $this->optional_bytes_wrapper->setFields($s['optional_bytes_wrapper'] as nonnull);
+      $this->optional_bytes_wrapper->setFields($s['optional_bytes_wrapper']);
     }
     if (Shapes::keyExists($s, 'repeated_bool_wrapper')) {
       $this->repeated_bool_wrapper = Vec\map($s['repeated_bool_wrapper'], ($v) ==> { $o = new \google\protobuf\BoolValue(); $o->setFields($v); return $o; });
@@ -3053,27 +3053,27 @@ class TestAllTypesProto3 implements \Protobuf\Message {
     }
     if (Shapes::keyExists($s, 'optional_duration')) {
       if ($this->optional_duration is null) $this->optional_duration = new \google\protobuf\Duration();
-      $this->optional_duration->setFields($s['optional_duration'] as nonnull);
+      $this->optional_duration->setFields($s['optional_duration']);
     }
     if (Shapes::keyExists($s, 'optional_timestamp')) {
       if ($this->optional_timestamp is null) $this->optional_timestamp = new \google\protobuf\Timestamp();
-      $this->optional_timestamp->setFields($s['optional_timestamp'] as nonnull);
+      $this->optional_timestamp->setFields($s['optional_timestamp']);
     }
     if (Shapes::keyExists($s, 'optional_field_mask')) {
       if ($this->optional_field_mask is null) $this->optional_field_mask = new \google\protobuf\FieldMask();
-      $this->optional_field_mask->setFields($s['optional_field_mask'] as nonnull);
+      $this->optional_field_mask->setFields($s['optional_field_mask']);
     }
     if (Shapes::keyExists($s, 'optional_struct')) {
       if ($this->optional_struct is null) $this->optional_struct = new \google\protobuf\Struct();
-      $this->optional_struct->setFields($s['optional_struct'] as nonnull);
+      $this->optional_struct->setFields($s['optional_struct']);
     }
     if (Shapes::keyExists($s, 'optional_any')) {
       if ($this->optional_any is null) $this->optional_any = new \google\protobuf\Any();
-      $this->optional_any->setFields($s['optional_any'] as nonnull);
+      $this->optional_any->setFields($s['optional_any']);
     }
     if (Shapes::keyExists($s, 'optional_value')) {
       if ($this->optional_value is null) $this->optional_value = new \google\protobuf\Value();
-      $this->optional_value->setFields($s['optional_value'] as nonnull);
+      $this->optional_value->setFields($s['optional_value']);
     }
     if (Shapes::keyExists($s, 'optional_null_value')) $this->optional_null_value = $s['optional_null_value'];
     if (Shapes::keyExists($s, 'repeated_duration')) {

--- a/generated/google/protobuf/test_messages_proto3_proto.php
+++ b/generated/google/protobuf/test_messages_proto3_proto.php
@@ -2929,12 +2929,10 @@ class TestAllTypesProto3 implements \Protobuf\Message {
     if (Shapes::keyExists($s, 'repeated_string')) $this->repeated_string = $s['repeated_string'];
     if (Shapes::keyExists($s, 'repeated_bytes')) $this->repeated_bytes = $s['repeated_bytes'];
     if (Shapes::keyExists($s, 'repeated_nested_message')) {
-      if ($this->repeated_nested_message is null) $this->repeated_nested_message = new \protobuf_test_messages\proto3\TestAllTypesProto3_NestedMessage();
-      $this->repeated_nested_message->setFields($s['repeated_nested_message'] as nonnull);
+      $this->repeated_nested_message = Vec\map($s['repeated_nested_message'], ($v) ==> { $o = new \protobuf_test_messages\proto3\TestAllTypesProto3_NestedMessage(); $o->setFields($v); return $o; });
     }
     if (Shapes::keyExists($s, 'repeated_foreign_message')) {
-      if ($this->repeated_foreign_message is null) $this->repeated_foreign_message = new \protobuf_test_messages\proto3\ForeignMessage();
-      $this->repeated_foreign_message->setFields($s['repeated_foreign_message'] as nonnull);
+      $this->repeated_foreign_message = Vec\map($s['repeated_foreign_message'], ($v) ==> { $o = new \protobuf_test_messages\proto3\ForeignMessage(); $o->setFields($v); return $o; });
     }
     if (Shapes::keyExists($s, 'repeated_nested_enum')) $this->repeated_nested_enum = $s['repeated_nested_enum'];
     if (Shapes::keyExists($s, 'repeated_foreign_enum')) $this->repeated_foreign_enum = $s['repeated_foreign_enum'];
@@ -3024,40 +3022,31 @@ class TestAllTypesProto3 implements \Protobuf\Message {
       $this->optional_bytes_wrapper->setFields($s['optional_bytes_wrapper'] as nonnull);
     }
     if (Shapes::keyExists($s, 'repeated_bool_wrapper')) {
-      if ($this->repeated_bool_wrapper is null) $this->repeated_bool_wrapper = new \google\protobuf\BoolValue();
-      $this->repeated_bool_wrapper->setFields($s['repeated_bool_wrapper'] as nonnull);
+      $this->repeated_bool_wrapper = Vec\map($s['repeated_bool_wrapper'], ($v) ==> { $o = new \google\protobuf\BoolValue(); $o->setFields($v); return $o; });
     }
     if (Shapes::keyExists($s, 'repeated_int32_wrapper')) {
-      if ($this->repeated_int32_wrapper is null) $this->repeated_int32_wrapper = new \google\protobuf\Int32Value();
-      $this->repeated_int32_wrapper->setFields($s['repeated_int32_wrapper'] as nonnull);
+      $this->repeated_int32_wrapper = Vec\map($s['repeated_int32_wrapper'], ($v) ==> { $o = new \google\protobuf\Int32Value(); $o->setFields($v); return $o; });
     }
     if (Shapes::keyExists($s, 'repeated_int64_wrapper')) {
-      if ($this->repeated_int64_wrapper is null) $this->repeated_int64_wrapper = new \google\protobuf\Int64Value();
-      $this->repeated_int64_wrapper->setFields($s['repeated_int64_wrapper'] as nonnull);
+      $this->repeated_int64_wrapper = Vec\map($s['repeated_int64_wrapper'], ($v) ==> { $o = new \google\protobuf\Int64Value(); $o->setFields($v); return $o; });
     }
     if (Shapes::keyExists($s, 'repeated_uint32_wrapper')) {
-      if ($this->repeated_uint32_wrapper is null) $this->repeated_uint32_wrapper = new \google\protobuf\UInt32Value();
-      $this->repeated_uint32_wrapper->setFields($s['repeated_uint32_wrapper'] as nonnull);
+      $this->repeated_uint32_wrapper = Vec\map($s['repeated_uint32_wrapper'], ($v) ==> { $o = new \google\protobuf\UInt32Value(); $o->setFields($v); return $o; });
     }
     if (Shapes::keyExists($s, 'repeated_uint64_wrapper')) {
-      if ($this->repeated_uint64_wrapper is null) $this->repeated_uint64_wrapper = new \google\protobuf\UInt64Value();
-      $this->repeated_uint64_wrapper->setFields($s['repeated_uint64_wrapper'] as nonnull);
+      $this->repeated_uint64_wrapper = Vec\map($s['repeated_uint64_wrapper'], ($v) ==> { $o = new \google\protobuf\UInt64Value(); $o->setFields($v); return $o; });
     }
     if (Shapes::keyExists($s, 'repeated_float_wrapper')) {
-      if ($this->repeated_float_wrapper is null) $this->repeated_float_wrapper = new \google\protobuf\FloatValue();
-      $this->repeated_float_wrapper->setFields($s['repeated_float_wrapper'] as nonnull);
+      $this->repeated_float_wrapper = Vec\map($s['repeated_float_wrapper'], ($v) ==> { $o = new \google\protobuf\FloatValue(); $o->setFields($v); return $o; });
     }
     if (Shapes::keyExists($s, 'repeated_double_wrapper')) {
-      if ($this->repeated_double_wrapper is null) $this->repeated_double_wrapper = new \google\protobuf\DoubleValue();
-      $this->repeated_double_wrapper->setFields($s['repeated_double_wrapper'] as nonnull);
+      $this->repeated_double_wrapper = Vec\map($s['repeated_double_wrapper'], ($v) ==> { $o = new \google\protobuf\DoubleValue(); $o->setFields($v); return $o; });
     }
     if (Shapes::keyExists($s, 'repeated_string_wrapper')) {
-      if ($this->repeated_string_wrapper is null) $this->repeated_string_wrapper = new \google\protobuf\StringValue();
-      $this->repeated_string_wrapper->setFields($s['repeated_string_wrapper'] as nonnull);
+      $this->repeated_string_wrapper = Vec\map($s['repeated_string_wrapper'], ($v) ==> { $o = new \google\protobuf\StringValue(); $o->setFields($v); return $o; });
     }
     if (Shapes::keyExists($s, 'repeated_bytes_wrapper')) {
-      if ($this->repeated_bytes_wrapper is null) $this->repeated_bytes_wrapper = new \google\protobuf\BytesValue();
-      $this->repeated_bytes_wrapper->setFields($s['repeated_bytes_wrapper'] as nonnull);
+      $this->repeated_bytes_wrapper = Vec\map($s['repeated_bytes_wrapper'], ($v) ==> { $o = new \google\protobuf\BytesValue(); $o->setFields($v); return $o; });
     }
     if (Shapes::keyExists($s, 'optional_duration')) {
       if ($this->optional_duration is null) $this->optional_duration = new \google\protobuf\Duration();
@@ -3085,32 +3074,25 @@ class TestAllTypesProto3 implements \Protobuf\Message {
     }
     if (Shapes::keyExists($s, 'optional_null_value')) $this->optional_null_value = $s['optional_null_value'];
     if (Shapes::keyExists($s, 'repeated_duration')) {
-      if ($this->repeated_duration is null) $this->repeated_duration = new \google\protobuf\Duration();
-      $this->repeated_duration->setFields($s['repeated_duration'] as nonnull);
+      $this->repeated_duration = Vec\map($s['repeated_duration'], ($v) ==> { $o = new \google\protobuf\Duration(); $o->setFields($v); return $o; });
     }
     if (Shapes::keyExists($s, 'repeated_timestamp')) {
-      if ($this->repeated_timestamp is null) $this->repeated_timestamp = new \google\protobuf\Timestamp();
-      $this->repeated_timestamp->setFields($s['repeated_timestamp'] as nonnull);
+      $this->repeated_timestamp = Vec\map($s['repeated_timestamp'], ($v) ==> { $o = new \google\protobuf\Timestamp(); $o->setFields($v); return $o; });
     }
     if (Shapes::keyExists($s, 'repeated_fieldmask')) {
-      if ($this->repeated_fieldmask is null) $this->repeated_fieldmask = new \google\protobuf\FieldMask();
-      $this->repeated_fieldmask->setFields($s['repeated_fieldmask'] as nonnull);
+      $this->repeated_fieldmask = Vec\map($s['repeated_fieldmask'], ($v) ==> { $o = new \google\protobuf\FieldMask(); $o->setFields($v); return $o; });
     }
     if (Shapes::keyExists($s, 'repeated_struct')) {
-      if ($this->repeated_struct is null) $this->repeated_struct = new \google\protobuf\Struct();
-      $this->repeated_struct->setFields($s['repeated_struct'] as nonnull);
+      $this->repeated_struct = Vec\map($s['repeated_struct'], ($v) ==> { $o = new \google\protobuf\Struct(); $o->setFields($v); return $o; });
     }
     if (Shapes::keyExists($s, 'repeated_any')) {
-      if ($this->repeated_any is null) $this->repeated_any = new \google\protobuf\Any();
-      $this->repeated_any->setFields($s['repeated_any'] as nonnull);
+      $this->repeated_any = Vec\map($s['repeated_any'], ($v) ==> { $o = new \google\protobuf\Any(); $o->setFields($v); return $o; });
     }
     if (Shapes::keyExists($s, 'repeated_value')) {
-      if ($this->repeated_value is null) $this->repeated_value = new \google\protobuf\Value();
-      $this->repeated_value->setFields($s['repeated_value'] as nonnull);
+      $this->repeated_value = Vec\map($s['repeated_value'], ($v) ==> { $o = new \google\protobuf\Value(); $o->setFields($v); return $o; });
     }
     if (Shapes::keyExists($s, 'repeated_list_value')) {
-      if ($this->repeated_list_value is null) $this->repeated_list_value = new \google\protobuf\ListValue();
-      $this->repeated_list_value->setFields($s['repeated_list_value'] as nonnull);
+      $this->repeated_list_value = Vec\map($s['repeated_list_value'], ($v) ==> { $o = new \google\protobuf\ListValue(); $o->setFields($v); return $o; });
     }
     if (Shapes::keyExists($s, 'fieldname1')) $this->fieldname1 = $s['fieldname1'];
     if (Shapes::keyExists($s, 'field_name2')) $this->field_name2 = $s['field_name2'];
@@ -3170,8 +3152,8 @@ class TestAllTypesProto3 implements \Protobuf\Message {
     if (!C\is_empty($this->repeated_bool)) $s['repeated_bool'] = $this->repeated_bool;
     if (!C\is_empty($this->repeated_string)) $s['repeated_string'] = $this->repeated_string;
     if (!C\is_empty($this->repeated_bytes)) $s['repeated_bytes'] = $this->repeated_bytes;
-    if (!C\is_empty($this->repeated_nested_message)) $s['repeated_nested_message'] = $this->repeated_nested_message;
-    if (!C\is_empty($this->repeated_foreign_message)) $s['repeated_foreign_message'] = $this->repeated_foreign_message;
+    if (!C\is_empty($this->repeated_nested_message)) $s['repeated_nested_message'] = Vec\map($this->repeated_nested_message, ($v) ==> $v->getNonDefaultFields());
+    if (!C\is_empty($this->repeated_foreign_message)) $s['repeated_foreign_message'] = Vec\map($this->repeated_foreign_message, ($v) ==> $v->getNonDefaultFields());
     if (!C\is_empty($this->repeated_nested_enum)) $s['repeated_nested_enum'] = $this->repeated_nested_enum;
     if (!C\is_empty($this->repeated_foreign_enum)) $s['repeated_foreign_enum'] = $this->repeated_foreign_enum;
     if (!C\is_empty($this->repeated_string_piece)) $s['repeated_string_piece'] = $this->repeated_string_piece;
@@ -3223,23 +3205,23 @@ class TestAllTypesProto3 implements \Protobuf\Message {
     if (!C\is_empty($this->map_string_foreign_message)) $s['map_string_foreign_message'] = Dict\map($this->map_string_foreign_message, ($v) ==> $v->getNonDefaultFields());
     if (!C\is_empty($this->map_string_nested_enum)) $s['map_string_nested_enum'] = $this->map_string_nested_enum;
     if (!C\is_empty($this->map_string_foreign_enum)) $s['map_string_foreign_enum'] = $this->map_string_foreign_enum;
-    if (!C\is_empty($this->repeated_bool_wrapper)) $s['repeated_bool_wrapper'] = $this->repeated_bool_wrapper;
-    if (!C\is_empty($this->repeated_int32_wrapper)) $s['repeated_int32_wrapper'] = $this->repeated_int32_wrapper;
-    if (!C\is_empty($this->repeated_int64_wrapper)) $s['repeated_int64_wrapper'] = $this->repeated_int64_wrapper;
-    if (!C\is_empty($this->repeated_uint32_wrapper)) $s['repeated_uint32_wrapper'] = $this->repeated_uint32_wrapper;
-    if (!C\is_empty($this->repeated_uint64_wrapper)) $s['repeated_uint64_wrapper'] = $this->repeated_uint64_wrapper;
-    if (!C\is_empty($this->repeated_float_wrapper)) $s['repeated_float_wrapper'] = $this->repeated_float_wrapper;
-    if (!C\is_empty($this->repeated_double_wrapper)) $s['repeated_double_wrapper'] = $this->repeated_double_wrapper;
-    if (!C\is_empty($this->repeated_string_wrapper)) $s['repeated_string_wrapper'] = $this->repeated_string_wrapper;
-    if (!C\is_empty($this->repeated_bytes_wrapper)) $s['repeated_bytes_wrapper'] = $this->repeated_bytes_wrapper;
+    if (!C\is_empty($this->repeated_bool_wrapper)) $s['repeated_bool_wrapper'] = Vec\map($this->repeated_bool_wrapper, ($v) ==> $v->getNonDefaultFields());
+    if (!C\is_empty($this->repeated_int32_wrapper)) $s['repeated_int32_wrapper'] = Vec\map($this->repeated_int32_wrapper, ($v) ==> $v->getNonDefaultFields());
+    if (!C\is_empty($this->repeated_int64_wrapper)) $s['repeated_int64_wrapper'] = Vec\map($this->repeated_int64_wrapper, ($v) ==> $v->getNonDefaultFields());
+    if (!C\is_empty($this->repeated_uint32_wrapper)) $s['repeated_uint32_wrapper'] = Vec\map($this->repeated_uint32_wrapper, ($v) ==> $v->getNonDefaultFields());
+    if (!C\is_empty($this->repeated_uint64_wrapper)) $s['repeated_uint64_wrapper'] = Vec\map($this->repeated_uint64_wrapper, ($v) ==> $v->getNonDefaultFields());
+    if (!C\is_empty($this->repeated_float_wrapper)) $s['repeated_float_wrapper'] = Vec\map($this->repeated_float_wrapper, ($v) ==> $v->getNonDefaultFields());
+    if (!C\is_empty($this->repeated_double_wrapper)) $s['repeated_double_wrapper'] = Vec\map($this->repeated_double_wrapper, ($v) ==> $v->getNonDefaultFields());
+    if (!C\is_empty($this->repeated_string_wrapper)) $s['repeated_string_wrapper'] = Vec\map($this->repeated_string_wrapper, ($v) ==> $v->getNonDefaultFields());
+    if (!C\is_empty($this->repeated_bytes_wrapper)) $s['repeated_bytes_wrapper'] = Vec\map($this->repeated_bytes_wrapper, ($v) ==> $v->getNonDefaultFields());
     if ($this->optional_null_value !== \google\protobuf\NullValue::FromInt(0)) $s['optional_null_value'] = $this->optional_null_value;
-    if (!C\is_empty($this->repeated_duration)) $s['repeated_duration'] = $this->repeated_duration;
-    if (!C\is_empty($this->repeated_timestamp)) $s['repeated_timestamp'] = $this->repeated_timestamp;
-    if (!C\is_empty($this->repeated_fieldmask)) $s['repeated_fieldmask'] = $this->repeated_fieldmask;
-    if (!C\is_empty($this->repeated_struct)) $s['repeated_struct'] = $this->repeated_struct;
-    if (!C\is_empty($this->repeated_any)) $s['repeated_any'] = $this->repeated_any;
-    if (!C\is_empty($this->repeated_value)) $s['repeated_value'] = $this->repeated_value;
-    if (!C\is_empty($this->repeated_list_value)) $s['repeated_list_value'] = $this->repeated_list_value;
+    if (!C\is_empty($this->repeated_duration)) $s['repeated_duration'] = Vec\map($this->repeated_duration, ($v) ==> $v->getNonDefaultFields());
+    if (!C\is_empty($this->repeated_timestamp)) $s['repeated_timestamp'] = Vec\map($this->repeated_timestamp, ($v) ==> $v->getNonDefaultFields());
+    if (!C\is_empty($this->repeated_fieldmask)) $s['repeated_fieldmask'] = Vec\map($this->repeated_fieldmask, ($v) ==> $v->getNonDefaultFields());
+    if (!C\is_empty($this->repeated_struct)) $s['repeated_struct'] = Vec\map($this->repeated_struct, ($v) ==> $v->getNonDefaultFields());
+    if (!C\is_empty($this->repeated_any)) $s['repeated_any'] = Vec\map($this->repeated_any, ($v) ==> $v->getNonDefaultFields());
+    if (!C\is_empty($this->repeated_value)) $s['repeated_value'] = Vec\map($this->repeated_value, ($v) ==> $v->getNonDefaultFields());
+    if (!C\is_empty($this->repeated_list_value)) $s['repeated_list_value'] = Vec\map($this->repeated_list_value, ($v) ==> $v->getNonDefaultFields());
     if ($this->fieldname1 !== 0) $s['fieldname1'] = $this->fieldname1;
     if ($this->field_name2 !== 0) $s['field_name2'] = $this->field_name2;
     if ($this->_field_name3 !== 0) $s['_field_name3'] = $this->_field_name3;

--- a/generated/google/protobuf/type_proto.php
+++ b/generated/google/protobuf/type_proto.php
@@ -85,6 +85,7 @@ class Type implements \Protobuf\Message {
     if (!C\is_empty($this->fields)) $s['fields'] = Vec\map($this->fields, ($v) ==> $v->getNonDefaultFields());
     if (!C\is_empty($this->oneofs)) $s['oneofs'] = $this->oneofs;
     if (!C\is_empty($this->options)) $s['options'] = Vec\map($this->options, ($v) ==> $v->getNonDefaultFields());
+    if ($this->source_context is nonnull) $s['source_context'] = $this->source_context->getNonDefaultFields();
     if ($this->syntax !== \google\protobuf\Syntax::FromInt(0)) $s['syntax'] = $this->syntax;
     return $s;
   }
@@ -647,6 +648,7 @@ class pb_Enum implements \Protobuf\Message {
     if ($this->name !== '') $s['name'] = $this->name;
     if (!C\is_empty($this->enumvalue)) $s['enumvalue'] = Vec\map($this->enumvalue, ($v) ==> $v->getNonDefaultFields());
     if (!C\is_empty($this->options)) $s['options'] = Vec\map($this->options, ($v) ==> $v->getNonDefaultFields());
+    if ($this->source_context is nonnull) $s['source_context'] = $this->source_context->getNonDefaultFields();
     if ($this->syntax !== \google\protobuf\Syntax::FromInt(0)) $s['syntax'] = $this->syntax;
     return $s;
   }
@@ -941,6 +943,7 @@ class Option implements \Protobuf\Message {
   public function getNonDefaultFields(): OptionFields {
     $s = shape();
     if ($this->name !== '') $s['name'] = $this->name;
+    if ($this->value is nonnull) $s['value'] = $this->value->getNonDefaultFields();
     return $s;
   }
 

--- a/generated/google/protobuf/type_proto.php
+++ b/generated/google/protobuf/type_proto.php
@@ -34,7 +34,7 @@ type TypeFields = shape (
   ?'fields' => vec<\google\protobuf\FieldFields>,
   ?'oneofs' => vec<string>,
   ?'options' => vec<\google\protobuf\OptionFields>,
-  ?'source_context' => ?\google\protobuf\SourceContextFields,
+  ?'source_context' => \google\protobuf\SourceContextFields,
   ?'syntax' => \google\protobuf\Syntax_enum_t,
 );
 class Type implements \Protobuf\Message {
@@ -74,7 +74,7 @@ class Type implements \Protobuf\Message {
     }
     if (Shapes::keyExists($s, 'source_context')) {
       if ($this->source_context is null) $this->source_context = new \google\protobuf\SourceContext();
-      $this->source_context->setFields($s['source_context'] as nonnull);
+      $this->source_context->setFields($s['source_context']);
     }
     if (Shapes::keyExists($s, 'syntax')) $this->syntax = $s['syntax'];
   }
@@ -602,7 +602,7 @@ type pb_EnumFields = shape (
   ?'name' => string,
   ?'enumvalue' => vec<\google\protobuf\EnumValueFields>,
   ?'options' => vec<\google\protobuf\OptionFields>,
-  ?'source_context' => ?\google\protobuf\SourceContextFields,
+  ?'source_context' => \google\protobuf\SourceContextFields,
   ?'syntax' => \google\protobuf\Syntax_enum_t,
 );
 class pb_Enum implements \Protobuf\Message {
@@ -638,7 +638,7 @@ class pb_Enum implements \Protobuf\Message {
     }
     if (Shapes::keyExists($s, 'source_context')) {
       if ($this->source_context is null) $this->source_context = new \google\protobuf\SourceContext();
-      $this->source_context->setFields($s['source_context'] as nonnull);
+      $this->source_context->setFields($s['source_context']);
     }
     if (Shapes::keyExists($s, 'syntax')) $this->syntax = $s['syntax'];
   }
@@ -916,7 +916,7 @@ class EnumValue implements \Protobuf\Message {
 
 type OptionFields = shape (
   ?'name' => string,
-  ?'value' => ?\google\protobuf\AnyFields,
+  ?'value' => \google\protobuf\AnyFields,
 );
 class Option implements \Protobuf\Message {
   public string $name;
@@ -936,7 +936,7 @@ class Option implements \Protobuf\Message {
     if (Shapes::keyExists($s, 'name')) $this->name = $s['name'];
     if (Shapes::keyExists($s, 'value')) {
       if ($this->value is null) $this->value = new \google\protobuf\Any();
-      $this->value->setFields($s['value'] as nonnull);
+      $this->value->setFields($s['value']);
     }
   }
 

--- a/generated/google/protobuf/type_proto.php
+++ b/generated/google/protobuf/type_proto.php
@@ -66,13 +66,11 @@ class Type implements \Protobuf\Message {
   public function setFields(TypeFields $s = shape()): void {
     if (Shapes::keyExists($s, 'name')) $this->name = $s['name'];
     if (Shapes::keyExists($s, 'fields')) {
-      if ($this->fields is null) $this->fields = new \google\protobuf\Field();
-      $this->fields->setFields($s['fields'] as nonnull);
+      $this->fields = Vec\map($s['fields'], ($v) ==> { $o = new \google\protobuf\Field(); $o->setFields($v); return $o; });
     }
     if (Shapes::keyExists($s, 'oneofs')) $this->oneofs = $s['oneofs'];
     if (Shapes::keyExists($s, 'options')) {
-      if ($this->options is null) $this->options = new \google\protobuf\Option();
-      $this->options->setFields($s['options'] as nonnull);
+      $this->options = Vec\map($s['options'], ($v) ==> { $o = new \google\protobuf\Option(); $o->setFields($v); return $o; });
     }
     if (Shapes::keyExists($s, 'source_context')) {
       if ($this->source_context is null) $this->source_context = new \google\protobuf\SourceContext();
@@ -84,9 +82,9 @@ class Type implements \Protobuf\Message {
   public function getNonDefaultFields(): TypeFields {
     $s = shape();
     if ($this->name !== '') $s['name'] = $this->name;
-    if (!C\is_empty($this->fields)) $s['fields'] = $this->fields;
+    if (!C\is_empty($this->fields)) $s['fields'] = Vec\map($this->fields, ($v) ==> $v->getNonDefaultFields());
     if (!C\is_empty($this->oneofs)) $s['oneofs'] = $this->oneofs;
-    if (!C\is_empty($this->options)) $s['options'] = $this->options;
+    if (!C\is_empty($this->options)) $s['options'] = Vec\map($this->options, ($v) ==> $v->getNonDefaultFields());
     if ($this->syntax !== \google\protobuf\Syntax::FromInt(0)) $s['syntax'] = $this->syntax;
     return $s;
   }
@@ -405,8 +403,7 @@ class Field implements \Protobuf\Message {
     if (Shapes::keyExists($s, 'oneof_index')) $this->oneof_index = $s['oneof_index'];
     if (Shapes::keyExists($s, 'packed')) $this->packed = $s['packed'];
     if (Shapes::keyExists($s, 'options')) {
-      if ($this->options is null) $this->options = new \google\protobuf\Option();
-      $this->options->setFields($s['options'] as nonnull);
+      $this->options = Vec\map($s['options'], ($v) ==> { $o = new \google\protobuf\Option(); $o->setFields($v); return $o; });
     }
     if (Shapes::keyExists($s, 'json_name')) $this->json_name = $s['json_name'];
     if (Shapes::keyExists($s, 'default_value')) $this->default_value = $s['default_value'];
@@ -421,7 +418,7 @@ class Field implements \Protobuf\Message {
     if ($this->type_url !== '') $s['type_url'] = $this->type_url;
     if ($this->oneof_index !== 0) $s['oneof_index'] = $this->oneof_index;
     if ($this->packed !== false) $s['packed'] = $this->packed;
-    if (!C\is_empty($this->options)) $s['options'] = $this->options;
+    if (!C\is_empty($this->options)) $s['options'] = Vec\map($this->options, ($v) ==> $v->getNonDefaultFields());
     if ($this->json_name !== '') $s['json_name'] = $this->json_name;
     if ($this->default_value !== '') $s['default_value'] = $this->default_value;
     return $s;
@@ -633,12 +630,10 @@ class pb_Enum implements \Protobuf\Message {
   public function setFields(pb_EnumFields $s = shape()): void {
     if (Shapes::keyExists($s, 'name')) $this->name = $s['name'];
     if (Shapes::keyExists($s, 'enumvalue')) {
-      if ($this->enumvalue is null) $this->enumvalue = new \google\protobuf\EnumValue();
-      $this->enumvalue->setFields($s['enumvalue'] as nonnull);
+      $this->enumvalue = Vec\map($s['enumvalue'], ($v) ==> { $o = new \google\protobuf\EnumValue(); $o->setFields($v); return $o; });
     }
     if (Shapes::keyExists($s, 'options')) {
-      if ($this->options is null) $this->options = new \google\protobuf\Option();
-      $this->options->setFields($s['options'] as nonnull);
+      $this->options = Vec\map($s['options'], ($v) ==> { $o = new \google\protobuf\Option(); $o->setFields($v); return $o; });
     }
     if (Shapes::keyExists($s, 'source_context')) {
       if ($this->source_context is null) $this->source_context = new \google\protobuf\SourceContext();
@@ -650,8 +645,8 @@ class pb_Enum implements \Protobuf\Message {
   public function getNonDefaultFields(): pb_EnumFields {
     $s = shape();
     if ($this->name !== '') $s['name'] = $this->name;
-    if (!C\is_empty($this->enumvalue)) $s['enumvalue'] = $this->enumvalue;
-    if (!C\is_empty($this->options)) $s['options'] = $this->options;
+    if (!C\is_empty($this->enumvalue)) $s['enumvalue'] = Vec\map($this->enumvalue, ($v) ==> $v->getNonDefaultFields());
+    if (!C\is_empty($this->options)) $s['options'] = Vec\map($this->options, ($v) ==> $v->getNonDefaultFields());
     if ($this->syntax !== \google\protobuf\Syntax::FromInt(0)) $s['syntax'] = $this->syntax;
     return $s;
   }
@@ -816,8 +811,7 @@ class EnumValue implements \Protobuf\Message {
     if (Shapes::keyExists($s, 'name')) $this->name = $s['name'];
     if (Shapes::keyExists($s, 'number')) $this->number = $s['number'];
     if (Shapes::keyExists($s, 'options')) {
-      if ($this->options is null) $this->options = new \google\protobuf\Option();
-      $this->options->setFields($s['options'] as nonnull);
+      $this->options = Vec\map($s['options'], ($v) ==> { $o = new \google\protobuf\Option(); $o->setFields($v); return $o; });
     }
   }
 
@@ -825,7 +819,7 @@ class EnumValue implements \Protobuf\Message {
     $s = shape();
     if ($this->name !== '') $s['name'] = $this->name;
     if ($this->number !== 0) $s['number'] = $this->number;
-    if (!C\is_empty($this->options)) $s['options'] = $this->options;
+    if (!C\is_empty($this->options)) $s['options'] = Vec\map($this->options, ($v) ==> $v->getNonDefaultFields());
     return $s;
   }
 

--- a/generated/test/example1_proto.php
+++ b/generated/test/example1_proto.php
@@ -402,6 +402,7 @@ class example1_Amap2Entry implements \Protobuf\Message {
   public function getNonDefaultFields(): example1_Amap2EntryFields {
     $s = shape();
     if ($this->key !== '') $s['key'] = $this->key;
+    if ($this->value is nonnull) $s['value'] = $this->value->getNonDefaultFields();
     return $s;
   }
 
@@ -676,9 +677,13 @@ class example1 implements \Protobuf\Message {
     if (!C\is_empty($this->manystring)) $s['manystring'] = $this->manystring;
     if (!C\is_empty($this->manyint64)) $s['manyint64'] = $this->manyint64;
     if (!C\is_empty($this->manyexample2)) $s['manyexample2'] = Vec\map($this->manyexample2, ($v) ==> $v->getNonDefaultFields());
+    if ($this->aexample2 is nonnull) $s['aexample2'] = $this->aexample2->getNonDefaultFields();
+    if ($this->aexample22 is nonnull) $s['aexample22'] = $this->aexample22->getNonDefaultFields();
+    if ($this->aexample23 is nonnull) $s['aexample23'] = $this->aexample23->getNonDefaultFields();
     if (!C\is_empty($this->amap)) $s['amap'] = $this->amap;
     if (!C\is_empty($this->amap2)) $s['amap2'] = Dict\map($this->amap2, ($v) ==> $v->getNonDefaultFields());
     if ($this->outoforder !== 0) $s['outoforder'] = $this->outoforder;
+    if ($this->anany is nonnull) $s['anany'] = $this->anany->getNonDefaultFields();
     if ($this->aoneof is nonnull && $this->aoneof->WhichOneof() !== example1_aoneof_oneof_t::NOT_SET) $s['aoneof'] = $this->aoneof;
     return $s;
   }

--- a/generated/test/example1_proto.php
+++ b/generated/test/example1_proto.php
@@ -375,7 +375,7 @@ class example1_AmapEntry implements \Protobuf\Message {
 
 type example1_Amap2EntryFields = shape (
   ?'key' => string,
-  ?'value' => ?\fiz\baz\example2Fields,
+  ?'value' => \fiz\baz\example2Fields,
 );
 class example1_Amap2Entry implements \Protobuf\Message {
   public string $key;
@@ -395,7 +395,7 @@ class example1_Amap2Entry implements \Protobuf\Message {
     if (Shapes::keyExists($s, 'key')) $this->key = $s['key'];
     if (Shapes::keyExists($s, 'value')) {
       if ($this->value is null) $this->value = new \fiz\baz\example2();
-      $this->value->setFields($s['value'] as nonnull);
+      $this->value->setFields($s['value']);
     }
   }
 
@@ -504,13 +504,13 @@ type example1Fields = shape (
   ?'manystring' => vec<string>,
   ?'manyint64' => vec<int>,
   ?'manyexample2' => vec<\fiz\baz\example2Fields>,
-  ?'aexample2' => ?\foo\bar\example1_example2Fields,
-  ?'aexample22' => ?\foo\bar\example2Fields,
-  ?'aexample23' => ?\fiz\baz\example2Fields,
+  ?'aexample2' => \foo\bar\example1_example2Fields,
+  ?'aexample22' => \foo\bar\example2Fields,
+  ?'aexample23' => \fiz\baz\example2Fields,
   ?'amap' => dict<string, string>,
   ?'amap2' => dict<string, \fiz\baz\example2Fields>,
   ?'outoforder' => int,
-  ?'anany' => ?\google\protobuf\AnyFields,
+  ?'anany' => \google\protobuf\AnyFields,
   ?'aoneof' => example1_aoneof,
 );
 class example1 implements \Protobuf\Message {
@@ -634,22 +634,22 @@ class example1 implements \Protobuf\Message {
     }
     if (Shapes::keyExists($s, 'aexample2')) {
       if ($this->aexample2 is null) $this->aexample2 = new \foo\bar\example1_example2();
-      $this->aexample2->setFields($s['aexample2'] as nonnull);
+      $this->aexample2->setFields($s['aexample2']);
     }
     if (Shapes::keyExists($s, 'aexample22')) {
       if ($this->aexample22 is null) $this->aexample22 = new \foo\bar\example2();
-      $this->aexample22->setFields($s['aexample22'] as nonnull);
+      $this->aexample22->setFields($s['aexample22']);
     }
     if (Shapes::keyExists($s, 'aexample23')) {
       if ($this->aexample23 is null) $this->aexample23 = new \fiz\baz\example2();
-      $this->aexample23->setFields($s['aexample23'] as nonnull);
+      $this->aexample23->setFields($s['aexample23']);
     }
     if (Shapes::keyExists($s, 'amap')) $this->amap = $s['amap'];
     if (Shapes::keyExists($s, 'amap2')) $this->amap2 = Dict\map($s['amap2'], ($v) ==> { $o = new \fiz\baz\example2(); $o->setFields($v); return $o; });
     if (Shapes::keyExists($s, 'outoforder')) $this->outoforder = $s['outoforder'];
     if (Shapes::keyExists($s, 'anany')) {
       if ($this->anany is null) $this->anany = new \google\protobuf\Any();
-      $this->anany->setFields($s['anany'] as nonnull);
+      $this->anany->setFields($s['anany']);
     }
     if (Shapes::keyExists($s, 'aoneof')) $this->aoneof = $s['aoneof'];
   }

--- a/generated/test/example1_proto.php
+++ b/generated/test/example1_proto.php
@@ -502,6 +502,7 @@ type example1Fields = shape (
   ?'aenum22' => \fiz\baz\AEnum2_enum_t,
   ?'manystring' => vec<string>,
   ?'manyint64' => vec<int>,
+  ?'manyexample2' => vec<\fiz\baz\example2Fields>,
   ?'aexample2' => ?\foo\bar\example1_example2Fields,
   ?'aexample22' => ?\foo\bar\example2Fields,
   ?'aexample23' => ?\fiz\baz\example2Fields,
@@ -532,6 +533,7 @@ class example1 implements \Protobuf\Message {
   public \fiz\baz\AEnum2_enum_t $aenum22;
   public vec<string> $manystring;
   public vec<int> $manyint64;
+  public vec<\fiz\baz\example2> $manyexample2;
   public ?\foo\bar\example1_example2 $aexample2;
   public ?\foo\bar\example2 $aexample22;
   public ?\fiz\baz\example2 $aexample23;
@@ -563,6 +565,7 @@ class example1 implements \Protobuf\Message {
     ?'aenum22' => \fiz\baz\AEnum2_enum_t,
     ?'manystring' => vec<string>,
     ?'manyint64' => vec<int>,
+    ?'manyexample2' => vec<\fiz\baz\example2>,
     ?'aexample2' => ?\foo\bar\example1_example2,
     ?'aexample22' => ?\foo\bar\example2,
     ?'aexample23' => ?\fiz\baz\example2,
@@ -592,6 +595,7 @@ class example1 implements \Protobuf\Message {
     $this->aenum22 = $s['aenum22'] ?? \fiz\baz\AEnum2::FromInt(0);
     $this->manystring = $s['manystring'] ?? vec[];
     $this->manyint64 = $s['manyint64'] ?? vec[];
+    $this->manyexample2 = $s['manyexample2'] ?? vec[];
     $this->aexample2 = $s['aexample2'] ?? null;
     $this->aexample22 = $s['aexample22'] ?? null;
     $this->aexample23 = $s['aexample23'] ?? null;
@@ -624,6 +628,9 @@ class example1 implements \Protobuf\Message {
     if (Shapes::keyExists($s, 'aenum22')) $this->aenum22 = $s['aenum22'];
     if (Shapes::keyExists($s, 'manystring')) $this->manystring = $s['manystring'];
     if (Shapes::keyExists($s, 'manyint64')) $this->manyint64 = $s['manyint64'];
+    if (Shapes::keyExists($s, 'manyexample2')) {
+      $this->manyexample2 = Vec\map($s['manyexample2'], ($v) ==> { $o = new \fiz\baz\example2(); $o->setFields($v); return $o; });
+    }
     if (Shapes::keyExists($s, 'aexample2')) {
       if ($this->aexample2 is null) $this->aexample2 = new \foo\bar\example1_example2();
       $this->aexample2->setFields($s['aexample2'] as nonnull);
@@ -668,6 +675,7 @@ class example1 implements \Protobuf\Message {
     if ($this->aenum22 !== \fiz\baz\AEnum2::FromInt(0)) $s['aenum22'] = $this->aenum22;
     if (!C\is_empty($this->manystring)) $s['manystring'] = $this->manystring;
     if (!C\is_empty($this->manyint64)) $s['manyint64'] = $this->manyint64;
+    if (!C\is_empty($this->manyexample2)) $s['manyexample2'] = Vec\map($this->manyexample2, ($v) ==> $v->getNonDefaultFields());
     if (!C\is_empty($this->amap)) $s['amap'] = $this->amap;
     if (!C\is_empty($this->amap2)) $s['amap2'] = Dict\map($this->amap2, ($v) ==> $v->getNonDefaultFields());
     if ($this->outoforder !== 0) $s['outoforder'] = $this->outoforder;
@@ -749,6 +757,11 @@ class example1 implements \Protobuf\Message {
           } else {
             $this->manyint64 []= $d->readVarint();
           }
+          break;
+        case 32:
+          $obj = new \fiz\baz\example2();
+          $obj->MergeFrom($d->readDecoder());
+          $this->manyexample2 []= $obj;
           break;
         case 40:
           if ($this->aexample2 == null) $this->aexample2 = new \foo\bar\example1_example2();
@@ -874,6 +887,11 @@ class example1 implements \Protobuf\Message {
       $packed->writeVarint($elem);
     }
     $e->writeEncoder($packed, 31);
+    foreach ($this->manyexample2 as $msg) {
+      $nested = new \Protobuf\Internal\Encoder();
+      $msg->WriteTo($nested);
+      $e->writeEncoder($nested, 32);
+    }
     $msg = $this->aexample2;
     if ($msg != null) {
       $nested = new \Protobuf\Internal\Encoder();
@@ -943,6 +961,7 @@ class example1 implements \Protobuf\Message {
     $e->writeEnum('aenum22', 'aenum22', \fiz\baz\AEnum2::ToStringDict(), $this->aenum22, false);
     $e->writePrimitiveList('manystring', 'manystring', $this->manystring);
     $e->writeInt64SignedList('manyint64', 'manyint64', $this->manyint64);
+    $e->writeMessageList('manyexample2', 'manyexample2', $this->manyexample2);
     $e->writeMessage('aexample2', 'aexample2', $this->aexample2, false);
     $e->writeMessage('aexample22', 'aexample22', $this->aexample22, false);
     $e->writeMessage('aexample23', 'aexample23', $this->aexample23, false);
@@ -1022,6 +1041,13 @@ class example1 implements \Protobuf\Message {
             $this->manyint64 []= \Protobuf\Internal\JsonDecoder::readInt64Signed($vv);
           }
           break;
+        case 'manyexample2':
+          foreach(\Protobuf\Internal\JsonDecoder::readList($v) as $vv) {
+            $obj = new \fiz\baz\example2();
+            $obj->MergeJsonFrom($vv);
+            $this->manyexample2 []= $obj;
+          }
+          break;
         case 'aexample2':
           if ($v === null) break;
           if ($this->aexample2 == null) $this->aexample2 = new \foo\bar\example1_example2();
@@ -1097,6 +1123,11 @@ class example1 implements \Protobuf\Message {
     $this->aenum22 = $o->aenum22;
     $this->manystring = $o->manystring;
     $this->manyint64 = $o->manyint64;
+    foreach ($o->manyexample2 as $v) {
+      $nv = new \fiz\baz\example2();
+      $nv->CopyFrom($v);
+      $this->manyexample2 []= $nv;
+    }
     $tmp = $o->aexample2;
     if ($tmp !== null) {
       $nv = new \foo\bar\example1_example2();
@@ -1173,19 +1204,19 @@ function RegisterExampleServiceServer(\Grpc\Server $server, ExampleServiceServer
 class XXX_FileDescriptor_test_example1__proto implements \Protobuf\Internal\FileDescriptor {
   const string NAME = 'test/example1.proto';
   const string RAW =
-  'eNpsVF1P2zAUrVv6kctX8VjlZYhZ1SQMD+niVh2atgcYSEh72OTxB5zhomptXKUpo/yj/c'
-  .'spdpyE0af4nHvOrX17bHiVqmU6UI9yvpipMFgkOtW4PdE6iGTiv7nX+n6mBoaOVpOBjNdW'
-  .'4z8zckv2+9BxDO5BS07jdMgJoog1RY76f71CFGICbXmnV9FMGRUSDhr7ZKZlSuoUsbrIUa'
-  .'Vto9rW8eMR2aKINUSOzC+srKFJEdsVDhaV8Yi0KGJbwkFTWVpPmyJ2IBwsKuMR6VDEsHAQ'
-  .'+9CRk+mjuhty4lHE2qLAZW08IkARa4kC4yPw5NIZtyli+6IkKtXxiOxQxLqiJPAhNGWk9Y'
-  .'zsUsQ6wgK7xzSZxvdkjyLmCQfNjKJ1qpZknyK2I3KET6AlVbyah+SQIrbH94M8AMHFdUaL'
-  .'vIw/5EJOXhshKYRFgoyD5w6OT6FtV5z0XO/pUxDJJ6d0dXwMMJfxOt/6MW0wT1SYbBYZst'
-  .'N/RxusIUoCn4MnXfYIo4htc//l7pxClGIcAhSAk1NjPfjfykVF9MwyJGfOkh9sg2WIB7Al'
-  .'53JBhrTBtvnbDYOby8V1nCZrYYSYQzP7cjIyjqPNDm4tVpqNUK9SPdHJnUpIaC5ChcFH0N'
-  .'E6H/DnLBs3NVEwuAdNradxSr5kN+umJizEZ9CUsYzX5Ic56GFgX4XAvQrBRZztIJP47ysv'
-  .'QCWI6FkQ/Y/gFcfFXWj8Vutcki2zXD/I2UqZq+8JCz7Vz5H/DaA89QbnSdW58T8pm/V70L'
-  .'IZxE1AX7u17HPVhcsOtKSOlZ6cOUWYlS6s4rJb51ewd20b/lTJw/SXwhw632N1q2//aPwi'
-  .'PKH/Mk/9WtQyAxz+CwAA//+zp37q';
+  'eNpsVF1v2jAUxVA+cvtFvQ55WdVZaFLdPoRhGKum7aFdK1Xawyavf8CspkKDGEHoSn/tfs'
+  .'pkO05Cy1Nyzj3H8b05NrxK1CLpqEc5nU1UN5rNdaJxfaR1NJTz8M291vcT1bH0cDnqyHjl'
+  .'NOGakTuy3YaGZ3ALanIcJz1OEEWsKlLU/hdkoi4mUJd3ejmcKKtCwkNrH020TEiZIlYWKS'
+  .'osWyku6/lBn2xRxCoiRfYLS2eoUsR2hYdZZdAnNYrYlvDQVhbOU6eIHQgPs8qgTxoUMSw8'
+  .'xCE05Gj8qO56nAQUsbrIcF4b9AlQxGoiw/gIArnwxm2K2L7IiUJ10Cc7FLGmyAl8CFU51H'
+  .'pCdiliDeGA22MyH8f3ZI8iFggP7YyGq0QtyD5FbEekCJ9ATap4Oe2SQ4rYHt+P0gBEF9eG'
+  .'FmkZf0iFnLy2QpIJswRZB08dHJ9C3b1x0vJrj5+ioXzySl/HxwBTGa/SrR/TCgtEgTGzMM'
+  .'hN/x2tsIrICfwRdgzw8SOUVtg2P8i+5gtiTYbPIZCZh1HEtnn4sqnMnItxFyADnJxa68Fz'
+  .'KxcF0ZqlR8685fkOCyLcgS05lTPSs+283TDvqZxdx8l8JawQc6iaJyd96zja7ODO4qRm8n'
+  .'qZ6JGe36k56drzU2DwETS0Tv/LFxOpm5LIGNyCqtbjOCFfzYG8KQkH8RlUZSzjFflpGz2M'
+  .'3GUS+cskuojNDowkfF+4OAr5RWv5DT9BkLWLm1D5o1apxLya4/AgJ0tlb4xAOPC5fI7C7w'
+  .'B51xucJ0Xnxn+SL9ZuQc1FF1cBfWuWzOOqCZcNqEkdKz0684quKV04xWWzzK9g79ot+EvN'
+  .'H8a/FebQ+BGrW337V+MX4emGL/PULg1rdoC9/wEAAP//vCmQgQ';
   public function Name(): string {
     return self::NAME;
   }

--- a/generated/test/example2_proto.php
+++ b/generated/test/example2_proto.php
@@ -105,7 +105,7 @@ class example2 implements \Protobuf\Message {
 }
 
 type refexample3Fields = shape (
-  ?'funky' => ?\FunkyFields,
+  ?'funky' => \FunkyFields,
 );
 class refexample3 implements \Protobuf\Message {
   public ?\Funky $funky;
@@ -121,7 +121,7 @@ class refexample3 implements \Protobuf\Message {
   public function setFields(refexample3Fields $s = shape()): void {
     if (Shapes::keyExists($s, 'funky')) {
       if ($this->funky is null) $this->funky = new \Funky();
-      $this->funky->setFields($s['funky'] as nonnull);
+      $this->funky->setFields($s['funky']);
     }
   }
 

--- a/generated/test/example2_proto.php
+++ b/generated/test/example2_proto.php
@@ -127,6 +127,7 @@ class refexample3 implements \Protobuf\Message {
 
   public function getNonDefaultFields(): refexample3Fields {
     $s = shape();
+    if ($this->funky is nonnull) $s['funky'] = $this->funky->getNonDefaultFields();
     return $s;
   }
 

--- a/generated/test/example3_proto.php
+++ b/generated/test/example3_proto.php
@@ -190,6 +190,8 @@ class Funky implements \Protobuf\Message {
 
   public function getNonDefaultFields(): FunkyFields {
     $s = shape();
+    if ($this->monkey is nonnull) $s['monkey'] = $this->monkey->getNonDefaultFields();
+    if ($this->dokey is nonnull) $s['dokey'] = $this->dokey->getNonDefaultFields();
     return $s;
   }
 

--- a/generated/test/example3_proto.php
+++ b/generated/test/example3_proto.php
@@ -160,8 +160,8 @@ class Funky_Monkey implements \Protobuf\Message {
 }
 
 type FunkyFields = shape (
-  ?'monkey' => ?\Funky_MonkeyFields,
-  ?'dokey' => ?\DonkeyFields,
+  ?'monkey' => \Funky_MonkeyFields,
+  ?'dokey' => \DonkeyFields,
 );
 class Funky implements \Protobuf\Message {
   public ?\Funky_Monkey $monkey;
@@ -180,11 +180,11 @@ class Funky implements \Protobuf\Message {
   public function setFields(FunkyFields $s = shape()): void {
     if (Shapes::keyExists($s, 'monkey')) {
       if ($this->monkey is null) $this->monkey = new \Funky_Monkey();
-      $this->monkey->setFields($s['monkey'] as nonnull);
+      $this->monkey->setFields($s['monkey']);
     }
     if (Shapes::keyExists($s, 'dokey')) {
       if ($this->dokey is null) $this->dokey = new \Donkey();
-      $this->dokey->setFields($s['dokey'] as nonnull);
+      $this->dokey->setFields($s['dokey']);
     }
   }
 

--- a/generated/test/example4_proto.php
+++ b/generated/test/example4_proto.php
@@ -82,7 +82,7 @@ class pb_Class implements \Protobuf\Message {
 }
 
 type pb_InterfaceFields = shape (
-  ?'class' => ?\pb_ClassFields,
+  ?'class' => \pb_ClassFields,
 );
 class pb_Interface implements \Protobuf\Message {
   public ?\pb_Class $class;
@@ -98,7 +98,7 @@ class pb_Interface implements \Protobuf\Message {
   public function setFields(pb_InterfaceFields $s = shape()): void {
     if (Shapes::keyExists($s, 'class')) {
       if ($this->class is null) $this->class = new \pb_Class();
-      $this->class->setFields($s['class'] as nonnull);
+      $this->class->setFields($s['class']);
     }
   }
 

--- a/generated/test/example4_proto.php
+++ b/generated/test/example4_proto.php
@@ -104,6 +104,7 @@ class pb_Interface implements \Protobuf\Message {
 
   public function getNonDefaultFields(): pb_InterfaceFields {
     $s = shape();
+    if ($this->class is nonnull) $s['class'] = $this->class->getNonDefaultFields();
     return $s;
   }
 

--- a/generated/test/exampleany_proto.php
+++ b/generated/test/exampleany_proto.php
@@ -4,7 +4,7 @@
 // Source: test/exampleany.proto
 
 type AnyTestFields = shape (
-  ?'any' => ?\google\protobuf\AnyFields,
+  ?'any' => \google\protobuf\AnyFields,
 );
 class AnyTest implements \Protobuf\Message {
   public ?\google\protobuf\Any $any;
@@ -20,7 +20,7 @@ class AnyTest implements \Protobuf\Message {
   public function setFields(AnyTestFields $s = shape()): void {
     if (Shapes::keyExists($s, 'any')) {
       if ($this->any is null) $this->any = new \google\protobuf\Any();
-      $this->any->setFields($s['any'] as nonnull);
+      $this->any->setFields($s['any']);
     }
   }
 

--- a/generated/test/exampleany_proto.php
+++ b/generated/test/exampleany_proto.php
@@ -26,6 +26,7 @@ class AnyTest implements \Protobuf\Message {
 
   public function getNonDefaultFields(): AnyTestFields {
     $s = shape();
+    if ($this->any is nonnull) $s['any'] = $this->any->getNonDefaultFields();
     return $s;
   }
 

--- a/protoc-gen-hack/plugin.go
+++ b/protoc-gen-hack/plugin.go
@@ -422,7 +422,7 @@ func (f field) labeledFieldsType() string {
 		return "vec<" + f.phpFieldsType() + ">"
 	}
 	if f.isMessageOrGroup() {
-		return "?" + f.phpFieldsType()
+		return f.phpFieldsType()
 	}
 	return f.phpFieldsType()
 }
@@ -1342,7 +1342,7 @@ func writeDescriptor(w *writer, dp *desc.DescriptorProto, ns *Namespace, prefixN
 		} else if f.isMessageOrGroup() {
 			w.p("if (Shapes::keyExists($s, '%s')) {", f.varName())
 			w.p("if ($this->%s is null) $this->%s = new %s();", f.varName(), f.varName(), f.phpType())
-			w.p("$this->%s->setFields($s['%s'] as nonnull);", f.varName(), f.varName())
+			w.p("$this->%s->setFields($s['%s']);", f.varName(), f.varName())
 			w.p("}")
 		} else {
 			w.p("if (Shapes::keyExists($s, '%s')) $this->%s = $s['%s'];", f.varName(), f.varName(), f.varName())

--- a/protoc-gen-hack/plugin.go
+++ b/protoc-gen-hack/plugin.go
@@ -1376,6 +1376,7 @@ func writeDescriptor(w *writer, dp *desc.DescriptorProto, ns *Namespace, prefixN
 				w.p("if (!C\\is_empty($this->%s)) $s['%s'] = $this->%s;", f.varName(), f.varName(), f.varName())
 			}
 		} else if f.isMessageOrGroup() {
+			w.p("if ($this->%s is nonnull) $s['%s'] = $this->%s->getNonDefaultFields();", f.varName(), f.varName(), f.varName())
 		} else {
 			w.p("if ($this->%s !== %s) $s['%s'] = $this->%s;", f.varName(), f.defaultValue(), f.varName(), f.varName())
 		}

--- a/protoc-gen-hack/plugin.go
+++ b/protoc-gen-hack/plugin.go
@@ -1334,6 +1334,11 @@ func writeDescriptor(w *writer, dp *desc.DescriptorProto, ns *Namespace, prefixN
 			} else {
 				w.p("if (Shapes::keyExists($s, '%s')) $this->%s = $s['%s'];", f.varName(), f.varName(), f.varName())
 			}
+		} else if f.isRepeated() && f.isMessageOrGroup() {
+			w.p("if (Shapes::keyExists($s, '%s')) {", f.varName())
+			w.p("$this->%s = Vec\\map($s['%s'], ($v) ==> { $o = new %s(); $o->setFields($v); return $o; });", f.varName(), f.varName(), f.phpType())
+			w.p("}")
+
 		} else if f.isMessageOrGroup() {
 			w.p("if (Shapes::keyExists($s, '%s')) {", f.varName())
 			w.p("if ($this->%s is null) $this->%s = new %s();", f.varName(), f.varName(), f.phpType())
@@ -1365,9 +1370,12 @@ func writeDescriptor(w *writer, dp *desc.DescriptorProto, ns *Namespace, prefixN
 				w.p("if (!C\\is_empty($this->%s)) $s['%s'] = $this->%s;", f.varName(), f.varName(), f.varName())
 			}
 		} else if f.isRepeated() {
-			w.p("if (!C\\is_empty($this->%s)) $s['%s'] = $this->%s;", f.varName(), f.varName(), f.varName())
+			if f.isMessageOrGroup() {
+				w.p("if (!C\\is_empty($this->%s)) $s['%s'] = Vec\\map($this->%s, ($v) ==> $v->getNonDefaultFields());", f.varName(), f.varName(), f.varName())
+			} else {
+				w.p("if (!C\\is_empty($this->%s)) $s['%s'] = $this->%s;", f.varName(), f.varName(), f.varName())
+			}
 		} else if f.isMessageOrGroup() {
-
 		} else {
 			w.p("if ($this->%s !== %s) $s['%s'] = $this->%s;", f.varName(), f.defaultValue(), f.varName(), f.varName())
 		}

--- a/test/example1.proto
+++ b/test/example1.proto
@@ -45,6 +45,7 @@ message example1 {
   // Repeated
   repeated string manystring = 30;
   repeated int64 manyint64 = 31;
+  repeated fiz.baz.example2 manyexample2 = 32;
 
   // Nested Messages / namespace test.
   message example2 {
@@ -54,6 +55,7 @@ message example1 {
   .foo.bar.example2 aexample22 = 41;
   .fiz.baz.example2 aexample23 = 42;
 
+  // maps
   map<string, string> amap = 51;
   map<string, fiz.baz.example2> amap2 = 52;
 


### PR DESCRIPTION
Fix three bugs that I found when running the new codegen for the actual webapp usage:

* Fix support for nested message types
* Add missing support to getDefaultFields for nested non-repeated message types
* Tweak the shape so that nested message types are optional but not nullable