### PR TITLE
Force float default value to contain '.'; Add Function/Attribute in t…

### DIFF
--- a/generated/google/protobuf/descriptor_proto.php
+++ b/generated/google/protobuf/descriptor_proto.php
@@ -2512,11 +2512,11 @@ class MessageOptions implements \Protobuf\Message {
 
 newtype FieldOptions_CType_enum_t as int = int;
 abstract class FieldOptions_CType {
-  const FieldOptions_CType_enum_t STRING = 0;
+  const FieldOptions_CType_enum_t pb_STRING = 0;
   const FieldOptions_CType_enum_t CORD = 1;
   const FieldOptions_CType_enum_t STRING_PIECE = 2;
   private static dict<int, string> $itos = dict[
-    0 => 'STRING',
+    0 => 'pb_STRING',
     1 => 'CORD',
     2 => 'STRING_PIECE',
   ];
@@ -2524,7 +2524,7 @@ abstract class FieldOptions_CType {
     return self::$itos;
   }
   private static dict<string, int> $stoi = dict[
-    'STRING' => 0,
+    'pb_STRING' => 0,
     'CORD' => 1,
     'STRING_PIECE' => 2,
   ];

--- a/generated/google/protobuf/test_messages_proto2_proto.php
+++ b/generated/google/protobuf/test_messages_proto2_proto.php
@@ -2533,8 +2533,8 @@ class TestAllTypesProto2 implements \Protobuf\Message {
     $this->default_fixed64 = $s['default_fixed64'] ?? -8323287284586094827;
     $this->default_sfixed32 = $s['default_sfixed32'] ?? -123456789;
     $this->default_sfixed64 = $s['default_sfixed64'] ?? -9123456789123456789;
-    $this->default_float = $s['default_float'] ?? 9e+09;
-    $this->default_double = $s['default_double'] ?? 7e+22;
+    $this->default_float = $s['default_float'] ?? (float)9e+09;
+    $this->default_double = $s['default_double'] ?? (float)7e+22;
     $this->default_bool = $s['default_bool'] ?? true;
     $this->default_string = $s['default_string'] ?? 'Rosebud';
     $this->default_bytes = $s['default_bytes'] ?? \stripcslashes('joshua');
@@ -3860,11 +3860,11 @@ class TestAllTypesProto2 implements \Protobuf\Message {
       $e->writeTag(250, 1);
       $e->writeLittleEndianInt64($this->default_sfixed64);
     }
-    if ($this->default_float !== 9e+09) {
+    if ($this->default_float !== (float)9e+09) {
       $e->writeTag(251, 5);
       $e->writeFloat($this->default_float);
     }
-    if ($this->default_double !== 7e+22) {
+    if ($this->default_double !== (float)7e+22) {
       $e->writeTag(252, 1);
       $e->writeDouble($this->default_double);
     }

--- a/protoc-gen-hack/plugin.go
+++ b/protoc-gen-hack/plugin.go
@@ -37,7 +37,7 @@ var (
 		"AsyncKeyedIterator", "AsyncGenerator", "Generator", "FormatString", "BuiltinEnum", "Throwable", "DateTime",
 		"stdClass", "DateTimeImmutable", "Stringish", "XHPChild", "IMemoizeParam", "typename", "IDisposable",
 		"IAsyncDisposable", "ImmVector", "Set", "ImmSet", "ImmMap", "Pair", "ConstVector", "Collection", "ConstMap",
-		"ConstCollection", "Attribute", "ClassAttribute", "EnumAttribute", "TypeAliasAttribute", "FunctionAttribute", "MethodAttribute",
+		"ConstCollection", "Class", "CLASS", "ClassAttribute", "EnumAttribute", "TypeAliasAttribute", "FunctionAttribute", "MethodAttribute",
 		"InstancePropertyAttribute", "StaticPropertyAttribute", "ParameterAttribute", "TypeParameterAttribute", "FileAttribute",
 		"TypeConstantAttribute", "Function", "tuple", "echo", "assert", "fun", "invariant", "invariant_violation", "inst_meth", "class_meth",
 		"meth_caller", "varray_or_darray", "callable", "object", "dynamic", "this", "mixed", "resource", "null", "namespace"}
@@ -1113,13 +1113,13 @@ func writeEnum(w *writer, ed *desc.EnumDescriptorProto, prefixNames []string) {
 	w.p("newtype %s as int = int;", typename)
 	w.p("abstract class %s {", name)
 	for _, v := range ed.Value {
-		w.p("const %s %s = %d;", typename, *v.Name, *v.Number)
+		w.p("const %s %s = %d;", typename, escapeReservedName(*v.Name), *v.Number)
 	}
 
 	w.p("private static dict<int, string> $itos = dict[")
 	w.i++
 	for _, v := range ed.Value {
-		w.p("%d => '%s',", v.GetNumber(), v.GetName())
+		w.p("%d => '%s',", v.GetNumber(), escapeReservedName(v.GetName()))
 	}
 	w.i--
 	w.p("];")
@@ -1131,7 +1131,7 @@ func writeEnum(w *writer, ed *desc.EnumDescriptorProto, prefixNames []string) {
 	w.p("private static dict<string, int> $stoi = dict[")
 	w.i++
 	for _, v := range ed.Value {
-		w.p("'%s' => %d,", v.GetName(), v.GetNumber())
+		w.p("'%s' => %d,", escapeReservedName(v.GetName()), v.GetNumber())
 	}
 	w.i--
 	w.p("];")

--- a/protoc-gen-hack/plugin.go
+++ b/protoc-gen-hack/plugin.go
@@ -37,9 +37,9 @@ var (
 		"AsyncKeyedIterator", "AsyncGenerator", "Generator", "FormatString", "BuiltinEnum", "Throwable", "DateTime",
 		"stdClass", "DateTimeImmutable", "Stringish", "XHPChild", "IMemoizeParam", "typename", "IDisposable",
 		"IAsyncDisposable", "ImmVector", "Set", "ImmSet", "ImmMap", "Pair", "ConstVector", "Collection", "ConstMap",
-		"ConstCollection", "ClassAttribute", "EnumAttribute", "TypeAliasAttribute", "FunctionAttribute", "MethodAttribute",
+		"ConstCollection", "Attribute", "ClassAttribute", "EnumAttribute", "TypeAliasAttribute", "FunctionAttribute", "MethodAttribute",
 		"InstancePropertyAttribute", "StaticPropertyAttribute", "ParameterAttribute", "TypeParameterAttribute", "FileAttribute",
-		"TypeConstantAttribute", "tuple", "echo", "assert", "fun", "invariant", "invariant_violation", "inst_meth", "class_meth",
+		"TypeConstantAttribute", "Function", "tuple", "echo", "assert", "fun", "invariant", "invariant_violation", "inst_meth", "class_meth",
 		"meth_caller", "varray_or_darray", "callable", "object", "dynamic", "this", "mixed", "resource", "null", "namespace"}
 )
 
@@ -414,6 +414,17 @@ func (f field) defaultValue() string {
 					panic(fmt.Errorf("failed to parse custom default uint64 value: %v", err))
 				}
 				return strconv.FormatInt(int64(u64), 10)
+			case desc.FieldDescriptorProto_TYPE_DOUBLE, desc.FieldDescriptorProto_TYPE_FLOAT:
+				// Force converting int-like values to float formatted values: 1 -> 1.0
+				f64, err := strconv.ParseFloat(dv, 32)
+				if err != nil {
+					panic(fmt.Errorf("failed to parse custom default float/double value: %v", err))
+				}
+				fs := strconv.FormatFloat(f64, 'f', -1, 32)
+				if !strings.Contains(fs, ".") {
+					fs += ".0"
+				}
+				return fs
 			case desc.FieldDescriptorProto_TYPE_STRING:
 				return "'" + strings.Replace(dv, "'", "\\'", -1) + "'"
 			case desc.FieldDescriptorProto_TYPE_BYTES:

--- a/protoc-gen-hack/plugin.go
+++ b/protoc-gen-hack/plugin.go
@@ -415,16 +415,8 @@ func (f field) defaultValue() string {
 				}
 				return strconv.FormatInt(int64(u64), 10)
 			case desc.FieldDescriptorProto_TYPE_DOUBLE, desc.FieldDescriptorProto_TYPE_FLOAT:
-				// Force converting int-like values to float formatted values: 1 -> 1.0
-				f64, err := strconv.ParseFloat(dv, 32)
-				if err != nil {
-					panic(fmt.Errorf("failed to parse custom default float/double value: %v", err))
-				}
-				fs := strconv.FormatFloat(f64, 'f', -1, 32)
-				if !strings.Contains(fs, ".") {
-					fs += ".0"
-				}
-				return fs
+				// Force converting int-like values to float values
+				return fmt.Sprintf("(float)%v", dv)
 			case desc.FieldDescriptorProto_TYPE_STRING:
 				return "'" + strings.Replace(dv, "'", "\\'", -1) + "'"
 			case desc.FieldDescriptorProto_TYPE_BYTES:


### PR DESCRIPTION
…he reserved keywords list

Default float values sometimes are set as int, we need to force a "ddd.ddd" like string so php can compile it as float.

Add Function/CLASS/Class as reserved keyword.

Escape enum item's names