### PR TITLE
Add ParseFrom static class

### DIFF
--- a/generated/external/com_google_protobuf/conformance/conformance_proto.php
+++ b/generated/external/com_google_protobuf/conformance/conformance_proto.php
@@ -90,6 +90,15 @@ class FailureSet implements \Protobuf\Message {
     return "conformance.FailureSet";
   }
 
+  public static function ParseFrom(string $input): ?FailureSet {
+    $msg = new FailureSet();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();
@@ -281,6 +290,15 @@ class ConformanceRequest implements \Protobuf\Message {
 
   public function MessageName(): string {
     return "conformance.ConformanceRequest";
+  }
+
+  public static function ParseFrom(string $input): ?ConformanceRequest {
+    $msg = new ConformanceRequest();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
   }
 
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
@@ -632,6 +650,15 @@ class ConformanceResponse implements \Protobuf\Message {
     return "conformance.ConformanceResponse";
   }
 
+  public static function ParseFrom(string $input): ?ConformanceResponse {
+    $msg = new ConformanceResponse();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();
@@ -734,6 +761,15 @@ class JspbEncodingConfig implements \Protobuf\Message {
 
   public function MessageName(): string {
     return "conformance.JspbEncodingConfig";
+  }
+
+  public static function ParseFrom(string $input): ?JspbEncodingConfig {
+    $msg = new JspbEncodingConfig();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
   }
 
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {

--- a/generated/google/protobuf/any_proto.php
+++ b/generated/google/protobuf/any_proto.php
@@ -22,6 +22,15 @@ class Any implements \Protobuf\Message {
     return "google.protobuf.Any";
   }
 
+  public static function ParseFrom(string $input): ?Any {
+    $msg = new Any();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();

--- a/generated/google/protobuf/api_proto.php
+++ b/generated/google/protobuf/api_proto.php
@@ -37,6 +37,15 @@ class Api implements \Protobuf\Message {
     return "google.protobuf.Api";
   }
 
+  public static function ParseFrom(string $input): ?Api {
+    $msg = new Api();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();
@@ -235,6 +244,15 @@ class Method implements \Protobuf\Message {
     return "google.protobuf.Method";
   }
 
+  public static function ParseFrom(string $input): ?Method {
+    $msg = new Method();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();
@@ -384,6 +402,15 @@ class Mixin implements \Protobuf\Message {
 
   public function MessageName(): string {
     return "google.protobuf.Mixin";
+  }
+
+  public static function ParseFrom(string $input): ?Mixin {
+    $msg = new Mixin();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
   }
 
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {

--- a/generated/google/protobuf/compiler/plugin_proto.php
+++ b/generated/google/protobuf/compiler/plugin_proto.php
@@ -28,6 +28,15 @@ class Version implements \Protobuf\Message {
     return "google.protobuf.compiler.Version";
   }
 
+  public static function ParseFrom(string $input): ?Version {
+    $msg = new Version();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();
@@ -136,6 +145,15 @@ class CodeGeneratorRequest implements \Protobuf\Message {
 
   public function MessageName(): string {
     return "google.protobuf.compiler.CodeGeneratorRequest";
+  }
+
+  public static function ParseFrom(string $input): ?CodeGeneratorRequest {
+    $msg = new CodeGeneratorRequest();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
   }
 
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
@@ -296,6 +314,15 @@ class CodeGeneratorResponse_File implements \Protobuf\Message {
     return "google.protobuf.compiler.CodeGeneratorResponse.File";
   }
 
+  public static function ParseFrom(string $input): ?CodeGeneratorResponse_File {
+    $msg = new CodeGeneratorResponse_File();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();
@@ -411,6 +438,15 @@ class CodeGeneratorResponse implements \Protobuf\Message {
 
   public function MessageName(): string {
     return "google.protobuf.compiler.CodeGeneratorResponse";
+  }
+
+  public static function ParseFrom(string $input): ?CodeGeneratorResponse {
+    $msg = new CodeGeneratorResponse();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
   }
 
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {

--- a/generated/google/protobuf/descriptor_proto.php
+++ b/generated/google/protobuf/descriptor_proto.php
@@ -19,6 +19,15 @@ class FileDescriptorSet implements \Protobuf\Message {
     return "google.protobuf.FileDescriptorSet";
   }
 
+  public static function ParseFrom(string $input): ?FileDescriptorSet {
+    $msg = new FileDescriptorSet();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();
@@ -126,6 +135,15 @@ class FileDescriptorProto implements \Protobuf\Message {
 
   public function MessageName(): string {
     return "google.protobuf.FileDescriptorProto";
+  }
+
+  public static function ParseFrom(string $input): ?FileDescriptorProto {
+    $msg = new FileDescriptorProto();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
   }
 
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
@@ -415,6 +433,15 @@ class DescriptorProto_ExtensionRange implements \Protobuf\Message {
     return "google.protobuf.DescriptorProto.ExtensionRange";
   }
 
+  public static function ParseFrom(string $input): ?DescriptorProto_ExtensionRange {
+    $msg = new DescriptorProto_ExtensionRange();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();
@@ -515,6 +542,15 @@ class DescriptorProto_ReservedRange implements \Protobuf\Message {
 
   public function MessageName(): string {
     return "google.protobuf.DescriptorProto.ReservedRange";
+  }
+
+  public static function ParseFrom(string $input): ?DescriptorProto_ReservedRange {
+    $msg = new DescriptorProto_ReservedRange();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
   }
 
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
@@ -619,6 +655,15 @@ class DescriptorProto implements \Protobuf\Message {
 
   public function MessageName(): string {
     return "google.protobuf.DescriptorProto";
+  }
+
+  public static function ParseFrom(string $input): ?DescriptorProto {
+    $msg = new DescriptorProto();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
   }
 
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
@@ -883,6 +928,15 @@ class ExtensionRangeOptions implements \Protobuf\Message {
     return "google.protobuf.ExtensionRangeOptions";
   }
 
+  public static function ParseFrom(string $input): ?ExtensionRangeOptions {
+    $msg = new ExtensionRangeOptions();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();
@@ -1090,6 +1144,15 @@ class FieldDescriptorProto implements \Protobuf\Message {
     return "google.protobuf.FieldDescriptorProto";
   }
 
+  public static function ParseFrom(string $input): ?FieldDescriptorProto {
+    $msg = new FieldDescriptorProto();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();
@@ -1288,6 +1351,15 @@ class OneofDescriptorProto implements \Protobuf\Message {
     return "google.protobuf.OneofDescriptorProto";
   }
 
+  public static function ParseFrom(string $input): ?OneofDescriptorProto {
+    $msg = new OneofDescriptorProto();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();
@@ -1378,6 +1450,15 @@ class EnumDescriptorProto_EnumReservedRange implements \Protobuf\Message {
     return "google.protobuf.EnumDescriptorProto.EnumReservedRange";
   }
 
+  public static function ParseFrom(string $input): ?EnumDescriptorProto_EnumReservedRange {
+    $msg = new EnumDescriptorProto_EnumReservedRange();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();
@@ -1465,6 +1546,15 @@ class EnumDescriptorProto implements \Protobuf\Message {
 
   public function MessageName(): string {
     return "google.protobuf.EnumDescriptorProto";
+  }
+
+  public static function ParseFrom(string $input): ?EnumDescriptorProto {
+    $msg = new EnumDescriptorProto();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
   }
 
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
@@ -1620,6 +1710,15 @@ class EnumValueDescriptorProto implements \Protobuf\Message {
     return "google.protobuf.EnumValueDescriptorProto";
   }
 
+  public static function ParseFrom(string $input): ?EnumValueDescriptorProto {
+    $msg = new EnumValueDescriptorProto();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();
@@ -1723,6 +1822,15 @@ class ServiceDescriptorProto implements \Protobuf\Message {
 
   public function MessageName(): string {
     return "google.protobuf.ServiceDescriptorProto";
+  }
+
+  public static function ParseFrom(string $input): ?ServiceDescriptorProto {
+    $msg = new ServiceDescriptorProto();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
   }
 
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
@@ -1848,6 +1956,15 @@ class MethodDescriptorProto implements \Protobuf\Message {
 
   public function MessageName(): string {
     return "google.protobuf.MethodDescriptorProto";
+  }
+
+  public static function ParseFrom(string $input): ?MethodDescriptorProto {
+    $msg = new MethodDescriptorProto();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
   }
 
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
@@ -2071,6 +2188,15 @@ class FileOptions implements \Protobuf\Message {
 
   public function MessageName(): string {
     return "google.protobuf.FileOptions";
+  }
+
+  public static function ParseFrom(string $input): ?FileOptions {
+    $msg = new FileOptions();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
   }
 
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
@@ -2401,6 +2527,15 @@ class MessageOptions implements \Protobuf\Message {
     return "google.protobuf.MessageOptions";
   }
 
+  public static function ParseFrom(string $input): ?MessageOptions {
+    $msg = new MessageOptions();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();
@@ -2602,6 +2737,15 @@ class FieldOptions implements \Protobuf\Message {
     return "google.protobuf.FieldOptions";
   }
 
+  public static function ParseFrom(string $input): ?FieldOptions {
+    $msg = new FieldOptions();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();
@@ -2762,6 +2906,15 @@ class OneofOptions implements \Protobuf\Message {
     return "google.protobuf.OneofOptions";
   }
 
+  public static function ParseFrom(string $input): ?OneofOptions {
+    $msg = new OneofOptions();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();
@@ -2842,6 +2995,15 @@ class EnumOptions implements \Protobuf\Message {
 
   public function MessageName(): string {
     return "google.protobuf.EnumOptions";
+  }
+
+  public static function ParseFrom(string $input): ?EnumOptions {
+    $msg = new EnumOptions();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
   }
 
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
@@ -2947,6 +3109,15 @@ class EnumValueOptions implements \Protobuf\Message {
     return "google.protobuf.EnumValueOptions";
   }
 
+  public static function ParseFrom(string $input): ?EnumValueOptions {
+    $msg = new EnumValueOptions();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();
@@ -3036,6 +3207,15 @@ class ServiceOptions implements \Protobuf\Message {
 
   public function MessageName(): string {
     return "google.protobuf.ServiceOptions";
+  }
+
+  public static function ParseFrom(string $input): ?ServiceOptions {
+    $msg = new ServiceOptions();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
   }
 
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
@@ -3160,6 +3340,15 @@ class MethodOptions implements \Protobuf\Message {
     return "google.protobuf.MethodOptions";
   }
 
+  public static function ParseFrom(string $input): ?MethodOptions {
+    $msg = new MethodOptions();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();
@@ -3263,6 +3452,15 @@ class UninterpretedOption_NamePart implements \Protobuf\Message {
     return "google.protobuf.UninterpretedOption.NamePart";
   }
 
+  public static function ParseFrom(string $input): ?UninterpretedOption_NamePart {
+    $msg = new UninterpretedOption_NamePart();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();
@@ -3356,6 +3554,15 @@ class UninterpretedOption implements \Protobuf\Message {
 
   public function MessageName(): string {
     return "google.protobuf.UninterpretedOption";
+  }
+
+  public static function ParseFrom(string $input): ?UninterpretedOption {
+    $msg = new UninterpretedOption();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
   }
 
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
@@ -3518,6 +3725,15 @@ class SourceCodeInfo_Location implements \Protobuf\Message {
     return "google.protobuf.SourceCodeInfo.Location";
   }
 
+  public static function ParseFrom(string $input): ?SourceCodeInfo_Location {
+    $msg = new SourceCodeInfo_Location();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();
@@ -3657,6 +3873,15 @@ class SourceCodeInfo implements \Protobuf\Message {
     return "google.protobuf.SourceCodeInfo";
   }
 
+  public static function ParseFrom(string $input): ?SourceCodeInfo {
+    $msg = new SourceCodeInfo();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();
@@ -3740,6 +3965,15 @@ class GeneratedCodeInfo_Annotation implements \Protobuf\Message {
 
   public function MessageName(): string {
     return "google.protobuf.GeneratedCodeInfo.Annotation";
+  }
+
+  public static function ParseFrom(string $input): ?GeneratedCodeInfo_Annotation {
+    $msg = new GeneratedCodeInfo_Annotation();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
   }
 
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
@@ -3853,6 +4087,15 @@ class GeneratedCodeInfo implements \Protobuf\Message {
 
   public function MessageName(): string {
     return "google.protobuf.GeneratedCodeInfo";
+  }
+
+  public static function ParseFrom(string $input): ?GeneratedCodeInfo {
+    $msg = new GeneratedCodeInfo();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
   }
 
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {

--- a/generated/google/protobuf/duration_proto.php
+++ b/generated/google/protobuf/duration_proto.php
@@ -22,6 +22,15 @@ class Duration implements \Protobuf\Message {
     return "google.protobuf.Duration";
   }
 
+  public static function ParseFrom(string $input): ?Duration {
+    $msg = new Duration();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();

--- a/generated/google/protobuf/empty_proto.php
+++ b/generated/google/protobuf/empty_proto.php
@@ -16,6 +16,15 @@ class pb_Empty implements \Protobuf\Message {
     return "google.protobuf.Empty";
   }
 
+  public static function ParseFrom(string $input): ?pb_Empty {
+    $msg = new pb_Empty();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();

--- a/generated/google/protobuf/field_mask_proto.php
+++ b/generated/google/protobuf/field_mask_proto.php
@@ -19,6 +19,15 @@ class FieldMask implements \Protobuf\Message {
     return "google.protobuf.FieldMask";
   }
 
+  public static function ParseFrom(string $input): ?FieldMask {
+    $msg = new FieldMask();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();

--- a/generated/google/protobuf/source_context_proto.php
+++ b/generated/google/protobuf/source_context_proto.php
@@ -19,6 +19,15 @@ class SourceContext implements \Protobuf\Message {
     return "google.protobuf.SourceContext";
   }
 
+  public static function ParseFrom(string $input): ?SourceContext {
+    $msg = new SourceContext();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();

--- a/generated/google/protobuf/struct_proto.php
+++ b/generated/google/protobuf/struct_proto.php
@@ -44,6 +44,15 @@ class Struct_FieldsEntry implements \Protobuf\Message {
     return "google.protobuf.Struct.FieldsEntry";
   }
 
+  public static function ParseFrom(string $input): ?Struct_FieldsEntry {
+    $msg = new Struct_FieldsEntry();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();
@@ -128,6 +137,15 @@ class Struct implements \Protobuf\Message {
 
   public function MessageName(): string {
     return "google.protobuf.Struct";
+  }
+
+  public static function ParseFrom(string $input): ?Struct {
+    $msg = new Struct();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
   }
 
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
@@ -366,6 +384,15 @@ class Value implements \Protobuf\Message {
     return "google.protobuf.Value";
   }
 
+  public static function ParseFrom(string $input): ?Value {
+    $msg = new Value();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();
@@ -482,6 +509,15 @@ class ListValue implements \Protobuf\Message {
 
   public function MessageName(): string {
     return "google.protobuf.ListValue";
+  }
+
+  public static function ParseFrom(string $input): ?ListValue {
+    $msg = new ListValue();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
   }
 
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {

--- a/generated/google/protobuf/test_messages_proto2_proto.php
+++ b/generated/google/protobuf/test_messages_proto2_proto.php
@@ -305,6 +305,15 @@ class TestAllTypesProto2_NestedMessage implements \Protobuf\Message {
     return "protobuf_test_messages.proto2.TestAllTypesProto2.NestedMessage";
   }
 
+  public static function ParseFrom(string $input): ?TestAllTypesProto2_NestedMessage {
+    $msg = new TestAllTypesProto2_NestedMessage();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();
@@ -395,6 +404,15 @@ class TestAllTypesProto2_MapInt32Int32Entry implements \Protobuf\Message {
     return "protobuf_test_messages.proto2.TestAllTypesProto2.MapInt32Int32Entry";
   }
 
+  public static function ParseFrom(string $input): ?TestAllTypesProto2_MapInt32Int32Entry {
+    $msg = new TestAllTypesProto2_MapInt32Int32Entry();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();
@@ -473,6 +491,15 @@ class TestAllTypesProto2_MapInt64Int64Entry implements \Protobuf\Message {
 
   public function MessageName(): string {
     return "protobuf_test_messages.proto2.TestAllTypesProto2.MapInt64Int64Entry";
+  }
+
+  public static function ParseFrom(string $input): ?TestAllTypesProto2_MapInt64Int64Entry {
+    $msg = new TestAllTypesProto2_MapInt64Int64Entry();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
   }
 
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
@@ -555,6 +582,15 @@ class TestAllTypesProto2_MapUint32Uint32Entry implements \Protobuf\Message {
     return "protobuf_test_messages.proto2.TestAllTypesProto2.MapUint32Uint32Entry";
   }
 
+  public static function ParseFrom(string $input): ?TestAllTypesProto2_MapUint32Uint32Entry {
+    $msg = new TestAllTypesProto2_MapUint32Uint32Entry();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();
@@ -633,6 +669,15 @@ class TestAllTypesProto2_MapUint64Uint64Entry implements \Protobuf\Message {
 
   public function MessageName(): string {
     return "protobuf_test_messages.proto2.TestAllTypesProto2.MapUint64Uint64Entry";
+  }
+
+  public static function ParseFrom(string $input): ?TestAllTypesProto2_MapUint64Uint64Entry {
+    $msg = new TestAllTypesProto2_MapUint64Uint64Entry();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
   }
 
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
@@ -715,6 +760,15 @@ class TestAllTypesProto2_MapSint32Sint32Entry implements \Protobuf\Message {
     return "protobuf_test_messages.proto2.TestAllTypesProto2.MapSint32Sint32Entry";
   }
 
+  public static function ParseFrom(string $input): ?TestAllTypesProto2_MapSint32Sint32Entry {
+    $msg = new TestAllTypesProto2_MapSint32Sint32Entry();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();
@@ -793,6 +847,15 @@ class TestAllTypesProto2_MapSint64Sint64Entry implements \Protobuf\Message {
 
   public function MessageName(): string {
     return "protobuf_test_messages.proto2.TestAllTypesProto2.MapSint64Sint64Entry";
+  }
+
+  public static function ParseFrom(string $input): ?TestAllTypesProto2_MapSint64Sint64Entry {
+    $msg = new TestAllTypesProto2_MapSint64Sint64Entry();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
   }
 
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
@@ -875,6 +938,15 @@ class TestAllTypesProto2_MapFixed32Fixed32Entry implements \Protobuf\Message {
     return "protobuf_test_messages.proto2.TestAllTypesProto2.MapFixed32Fixed32Entry";
   }
 
+  public static function ParseFrom(string $input): ?TestAllTypesProto2_MapFixed32Fixed32Entry {
+    $msg = new TestAllTypesProto2_MapFixed32Fixed32Entry();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();
@@ -953,6 +1025,15 @@ class TestAllTypesProto2_MapFixed64Fixed64Entry implements \Protobuf\Message {
 
   public function MessageName(): string {
     return "protobuf_test_messages.proto2.TestAllTypesProto2.MapFixed64Fixed64Entry";
+  }
+
+  public static function ParseFrom(string $input): ?TestAllTypesProto2_MapFixed64Fixed64Entry {
+    $msg = new TestAllTypesProto2_MapFixed64Fixed64Entry();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
   }
 
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
@@ -1035,6 +1116,15 @@ class TestAllTypesProto2_MapSfixed32Sfixed32Entry implements \Protobuf\Message {
     return "protobuf_test_messages.proto2.TestAllTypesProto2.MapSfixed32Sfixed32Entry";
   }
 
+  public static function ParseFrom(string $input): ?TestAllTypesProto2_MapSfixed32Sfixed32Entry {
+    $msg = new TestAllTypesProto2_MapSfixed32Sfixed32Entry();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();
@@ -1113,6 +1203,15 @@ class TestAllTypesProto2_MapSfixed64Sfixed64Entry implements \Protobuf\Message {
 
   public function MessageName(): string {
     return "protobuf_test_messages.proto2.TestAllTypesProto2.MapSfixed64Sfixed64Entry";
+  }
+
+  public static function ParseFrom(string $input): ?TestAllTypesProto2_MapSfixed64Sfixed64Entry {
+    $msg = new TestAllTypesProto2_MapSfixed64Sfixed64Entry();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
   }
 
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
@@ -1195,6 +1294,15 @@ class TestAllTypesProto2_MapInt32FloatEntry implements \Protobuf\Message {
     return "protobuf_test_messages.proto2.TestAllTypesProto2.MapInt32FloatEntry";
   }
 
+  public static function ParseFrom(string $input): ?TestAllTypesProto2_MapInt32FloatEntry {
+    $msg = new TestAllTypesProto2_MapInt32FloatEntry();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();
@@ -1273,6 +1381,15 @@ class TestAllTypesProto2_MapInt32DoubleEntry implements \Protobuf\Message {
 
   public function MessageName(): string {
     return "protobuf_test_messages.proto2.TestAllTypesProto2.MapInt32DoubleEntry";
+  }
+
+  public static function ParseFrom(string $input): ?TestAllTypesProto2_MapInt32DoubleEntry {
+    $msg = new TestAllTypesProto2_MapInt32DoubleEntry();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
   }
 
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
@@ -1355,6 +1472,15 @@ class TestAllTypesProto2_MapBoolBoolEntry implements \Protobuf\Message {
     return "protobuf_test_messages.proto2.TestAllTypesProto2.MapBoolBoolEntry";
   }
 
+  public static function ParseFrom(string $input): ?TestAllTypesProto2_MapBoolBoolEntry {
+    $msg = new TestAllTypesProto2_MapBoolBoolEntry();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();
@@ -1433,6 +1559,15 @@ class TestAllTypesProto2_MapStringStringEntry implements \Protobuf\Message {
 
   public function MessageName(): string {
     return "protobuf_test_messages.proto2.TestAllTypesProto2.MapStringStringEntry";
+  }
+
+  public static function ParseFrom(string $input): ?TestAllTypesProto2_MapStringStringEntry {
+    $msg = new TestAllTypesProto2_MapStringStringEntry();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
   }
 
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
@@ -1515,6 +1650,15 @@ class TestAllTypesProto2_MapStringBytesEntry implements \Protobuf\Message {
     return "protobuf_test_messages.proto2.TestAllTypesProto2.MapStringBytesEntry";
   }
 
+  public static function ParseFrom(string $input): ?TestAllTypesProto2_MapStringBytesEntry {
+    $msg = new TestAllTypesProto2_MapStringBytesEntry();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();
@@ -1593,6 +1737,15 @@ class TestAllTypesProto2_MapStringNestedMessageEntry implements \Protobuf\Messag
 
   public function MessageName(): string {
     return "protobuf_test_messages.proto2.TestAllTypesProto2.MapStringNestedMessageEntry";
+  }
+
+  public static function ParseFrom(string $input): ?TestAllTypesProto2_MapStringNestedMessageEntry {
+    $msg = new TestAllTypesProto2_MapStringNestedMessageEntry();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
   }
 
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
@@ -1685,6 +1838,15 @@ class TestAllTypesProto2_MapStringForeignMessageEntry implements \Protobuf\Messa
     return "protobuf_test_messages.proto2.TestAllTypesProto2.MapStringForeignMessageEntry";
   }
 
+  public static function ParseFrom(string $input): ?TestAllTypesProto2_MapStringForeignMessageEntry {
+    $msg = new TestAllTypesProto2_MapStringForeignMessageEntry();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();
@@ -1775,6 +1937,15 @@ class TestAllTypesProto2_MapStringNestedEnumEntry implements \Protobuf\Message {
     return "protobuf_test_messages.proto2.TestAllTypesProto2.MapStringNestedEnumEntry";
   }
 
+  public static function ParseFrom(string $input): ?TestAllTypesProto2_MapStringNestedEnumEntry {
+    $msg = new TestAllTypesProto2_MapStringNestedEnumEntry();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();
@@ -1853,6 +2024,15 @@ class TestAllTypesProto2_MapStringForeignEnumEntry implements \Protobuf\Message 
 
   public function MessageName(): string {
     return "protobuf_test_messages.proto2.TestAllTypesProto2.MapStringForeignEnumEntry";
+  }
+
+  public static function ParseFrom(string $input): ?TestAllTypesProto2_MapStringForeignEnumEntry {
+    $msg = new TestAllTypesProto2_MapStringForeignEnumEntry();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
   }
 
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
@@ -1935,6 +2115,15 @@ class TestAllTypesProto2_Data implements \Protobuf\Message {
     return "protobuf_test_messages.proto2.TestAllTypesProto2.Data";
   }
 
+  public static function ParseFrom(string $input): ?TestAllTypesProto2_Data {
+    $msg = new TestAllTypesProto2_Data();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();
@@ -2009,6 +2198,15 @@ class TestAllTypesProto2_MessageSetCorrect implements \Protobuf\Message {
     return "protobuf_test_messages.proto2.TestAllTypesProto2.MessageSetCorrect";
   }
 
+  public static function ParseFrom(string $input): ?TestAllTypesProto2_MessageSetCorrect {
+    $msg = new TestAllTypesProto2_MessageSetCorrect();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();
@@ -2060,6 +2258,15 @@ class TestAllTypesProto2_MessageSetCorrectExtension1 implements \Protobuf\Messag
 
   public function MessageName(): string {
     return "protobuf_test_messages.proto2.TestAllTypesProto2.MessageSetCorrectExtension1";
+  }
+
+  public static function ParseFrom(string $input): ?TestAllTypesProto2_MessageSetCorrectExtension1 {
+    $msg = new TestAllTypesProto2_MessageSetCorrectExtension1();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
   }
 
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
@@ -2125,6 +2332,15 @@ class TestAllTypesProto2_MessageSetCorrectExtension2 implements \Protobuf\Messag
 
   public function MessageName(): string {
     return "protobuf_test_messages.proto2.TestAllTypesProto2.MessageSetCorrectExtension2";
+  }
+
+  public static function ParseFrom(string $input): ?TestAllTypesProto2_MessageSetCorrectExtension2 {
+    $msg = new TestAllTypesProto2_MessageSetCorrectExtension2();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
   }
 
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
@@ -2562,6 +2778,15 @@ class TestAllTypesProto2 implements \Protobuf\Message {
 
   public function MessageName(): string {
     return "protobuf_test_messages.proto2.TestAllTypesProto2";
+  }
+
+  public static function ParseFrom(string $input): ?TestAllTypesProto2 {
+    $msg = new TestAllTypesProto2();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
   }
 
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
@@ -4871,6 +5096,15 @@ class ForeignMessageProto2 implements \Protobuf\Message {
     return "protobuf_test_messages.proto2.ForeignMessageProto2";
   }
 
+  public static function ParseFrom(string $input): ?ForeignMessageProto2 {
+    $msg = new ForeignMessageProto2();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();
@@ -4934,6 +5168,15 @@ class UnknownToTestAllTypes_OptionalGroup implements \Protobuf\Message {
 
   public function MessageName(): string {
     return "protobuf_test_messages.proto2.UnknownToTestAllTypes.OptionalGroup";
+  }
+
+  public static function ParseFrom(string $input): ?UnknownToTestAllTypes_OptionalGroup {
+    $msg = new UnknownToTestAllTypes_OptionalGroup();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
   }
 
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
@@ -5014,6 +5257,15 @@ class UnknownToTestAllTypes implements \Protobuf\Message {
 
   public function MessageName(): string {
     return "protobuf_test_messages.proto2.UnknownToTestAllTypes";
+  }
+
+  public static function ParseFrom(string $input): ?UnknownToTestAllTypes {
+    $msg = new UnknownToTestAllTypes();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
   }
 
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
@@ -5167,6 +5419,15 @@ class NullHypothesisProto2 implements \Protobuf\Message {
     return "protobuf_test_messages.proto2.NullHypothesisProto2";
   }
 
+  public static function ParseFrom(string $input): ?NullHypothesisProto2 {
+    $msg = new NullHypothesisProto2();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();
@@ -5242,6 +5503,15 @@ class EnumOnlyProto2 implements \Protobuf\Message {
     return "protobuf_test_messages.proto2.EnumOnlyProto2";
   }
 
+  public static function ParseFrom(string $input): ?EnumOnlyProto2 {
+    $msg = new EnumOnlyProto2();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();
@@ -5293,6 +5563,15 @@ class OneStringProto2 implements \Protobuf\Message {
 
   public function MessageName(): string {
     return "protobuf_test_messages.proto2.OneStringProto2";
+  }
+
+  public static function ParseFrom(string $input): ?OneStringProto2 {
+    $msg = new OneStringProto2();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
   }
 
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {

--- a/generated/google/protobuf/test_messages_proto3_proto.php
+++ b/generated/google/protobuf/test_messages_proto3_proto.php
@@ -364,6 +364,15 @@ class TestAllTypesProto3_NestedMessage implements \Protobuf\Message {
     return "protobuf_test_messages.proto3.TestAllTypesProto3.NestedMessage";
   }
 
+  public static function ParseFrom(string $input): ?TestAllTypesProto3_NestedMessage {
+    $msg = new TestAllTypesProto3_NestedMessage();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();
@@ -454,6 +463,15 @@ class TestAllTypesProto3_MapInt32Int32Entry implements \Protobuf\Message {
     return "protobuf_test_messages.proto3.TestAllTypesProto3.MapInt32Int32Entry";
   }
 
+  public static function ParseFrom(string $input): ?TestAllTypesProto3_MapInt32Int32Entry {
+    $msg = new TestAllTypesProto3_MapInt32Int32Entry();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();
@@ -532,6 +550,15 @@ class TestAllTypesProto3_MapInt64Int64Entry implements \Protobuf\Message {
 
   public function MessageName(): string {
     return "protobuf_test_messages.proto3.TestAllTypesProto3.MapInt64Int64Entry";
+  }
+
+  public static function ParseFrom(string $input): ?TestAllTypesProto3_MapInt64Int64Entry {
+    $msg = new TestAllTypesProto3_MapInt64Int64Entry();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
   }
 
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
@@ -614,6 +641,15 @@ class TestAllTypesProto3_MapUint32Uint32Entry implements \Protobuf\Message {
     return "protobuf_test_messages.proto3.TestAllTypesProto3.MapUint32Uint32Entry";
   }
 
+  public static function ParseFrom(string $input): ?TestAllTypesProto3_MapUint32Uint32Entry {
+    $msg = new TestAllTypesProto3_MapUint32Uint32Entry();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();
@@ -692,6 +728,15 @@ class TestAllTypesProto3_MapUint64Uint64Entry implements \Protobuf\Message {
 
   public function MessageName(): string {
     return "protobuf_test_messages.proto3.TestAllTypesProto3.MapUint64Uint64Entry";
+  }
+
+  public static function ParseFrom(string $input): ?TestAllTypesProto3_MapUint64Uint64Entry {
+    $msg = new TestAllTypesProto3_MapUint64Uint64Entry();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
   }
 
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
@@ -774,6 +819,15 @@ class TestAllTypesProto3_MapSint32Sint32Entry implements \Protobuf\Message {
     return "protobuf_test_messages.proto3.TestAllTypesProto3.MapSint32Sint32Entry";
   }
 
+  public static function ParseFrom(string $input): ?TestAllTypesProto3_MapSint32Sint32Entry {
+    $msg = new TestAllTypesProto3_MapSint32Sint32Entry();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();
@@ -852,6 +906,15 @@ class TestAllTypesProto3_MapSint64Sint64Entry implements \Protobuf\Message {
 
   public function MessageName(): string {
     return "protobuf_test_messages.proto3.TestAllTypesProto3.MapSint64Sint64Entry";
+  }
+
+  public static function ParseFrom(string $input): ?TestAllTypesProto3_MapSint64Sint64Entry {
+    $msg = new TestAllTypesProto3_MapSint64Sint64Entry();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
   }
 
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
@@ -934,6 +997,15 @@ class TestAllTypesProto3_MapFixed32Fixed32Entry implements \Protobuf\Message {
     return "protobuf_test_messages.proto3.TestAllTypesProto3.MapFixed32Fixed32Entry";
   }
 
+  public static function ParseFrom(string $input): ?TestAllTypesProto3_MapFixed32Fixed32Entry {
+    $msg = new TestAllTypesProto3_MapFixed32Fixed32Entry();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();
@@ -1012,6 +1084,15 @@ class TestAllTypesProto3_MapFixed64Fixed64Entry implements \Protobuf\Message {
 
   public function MessageName(): string {
     return "protobuf_test_messages.proto3.TestAllTypesProto3.MapFixed64Fixed64Entry";
+  }
+
+  public static function ParseFrom(string $input): ?TestAllTypesProto3_MapFixed64Fixed64Entry {
+    $msg = new TestAllTypesProto3_MapFixed64Fixed64Entry();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
   }
 
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
@@ -1094,6 +1175,15 @@ class TestAllTypesProto3_MapSfixed32Sfixed32Entry implements \Protobuf\Message {
     return "protobuf_test_messages.proto3.TestAllTypesProto3.MapSfixed32Sfixed32Entry";
   }
 
+  public static function ParseFrom(string $input): ?TestAllTypesProto3_MapSfixed32Sfixed32Entry {
+    $msg = new TestAllTypesProto3_MapSfixed32Sfixed32Entry();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();
@@ -1172,6 +1262,15 @@ class TestAllTypesProto3_MapSfixed64Sfixed64Entry implements \Protobuf\Message {
 
   public function MessageName(): string {
     return "protobuf_test_messages.proto3.TestAllTypesProto3.MapSfixed64Sfixed64Entry";
+  }
+
+  public static function ParseFrom(string $input): ?TestAllTypesProto3_MapSfixed64Sfixed64Entry {
+    $msg = new TestAllTypesProto3_MapSfixed64Sfixed64Entry();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
   }
 
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
@@ -1254,6 +1353,15 @@ class TestAllTypesProto3_MapInt32FloatEntry implements \Protobuf\Message {
     return "protobuf_test_messages.proto3.TestAllTypesProto3.MapInt32FloatEntry";
   }
 
+  public static function ParseFrom(string $input): ?TestAllTypesProto3_MapInt32FloatEntry {
+    $msg = new TestAllTypesProto3_MapInt32FloatEntry();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();
@@ -1332,6 +1440,15 @@ class TestAllTypesProto3_MapInt32DoubleEntry implements \Protobuf\Message {
 
   public function MessageName(): string {
     return "protobuf_test_messages.proto3.TestAllTypesProto3.MapInt32DoubleEntry";
+  }
+
+  public static function ParseFrom(string $input): ?TestAllTypesProto3_MapInt32DoubleEntry {
+    $msg = new TestAllTypesProto3_MapInt32DoubleEntry();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
   }
 
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
@@ -1414,6 +1531,15 @@ class TestAllTypesProto3_MapBoolBoolEntry implements \Protobuf\Message {
     return "protobuf_test_messages.proto3.TestAllTypesProto3.MapBoolBoolEntry";
   }
 
+  public static function ParseFrom(string $input): ?TestAllTypesProto3_MapBoolBoolEntry {
+    $msg = new TestAllTypesProto3_MapBoolBoolEntry();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();
@@ -1492,6 +1618,15 @@ class TestAllTypesProto3_MapStringStringEntry implements \Protobuf\Message {
 
   public function MessageName(): string {
     return "protobuf_test_messages.proto3.TestAllTypesProto3.MapStringStringEntry";
+  }
+
+  public static function ParseFrom(string $input): ?TestAllTypesProto3_MapStringStringEntry {
+    $msg = new TestAllTypesProto3_MapStringStringEntry();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
   }
 
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
@@ -1574,6 +1709,15 @@ class TestAllTypesProto3_MapStringBytesEntry implements \Protobuf\Message {
     return "protobuf_test_messages.proto3.TestAllTypesProto3.MapStringBytesEntry";
   }
 
+  public static function ParseFrom(string $input): ?TestAllTypesProto3_MapStringBytesEntry {
+    $msg = new TestAllTypesProto3_MapStringBytesEntry();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();
@@ -1652,6 +1796,15 @@ class TestAllTypesProto3_MapStringNestedMessageEntry implements \Protobuf\Messag
 
   public function MessageName(): string {
     return "protobuf_test_messages.proto3.TestAllTypesProto3.MapStringNestedMessageEntry";
+  }
+
+  public static function ParseFrom(string $input): ?TestAllTypesProto3_MapStringNestedMessageEntry {
+    $msg = new TestAllTypesProto3_MapStringNestedMessageEntry();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
   }
 
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
@@ -1744,6 +1897,15 @@ class TestAllTypesProto3_MapStringForeignMessageEntry implements \Protobuf\Messa
     return "protobuf_test_messages.proto3.TestAllTypesProto3.MapStringForeignMessageEntry";
   }
 
+  public static function ParseFrom(string $input): ?TestAllTypesProto3_MapStringForeignMessageEntry {
+    $msg = new TestAllTypesProto3_MapStringForeignMessageEntry();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();
@@ -1834,6 +1996,15 @@ class TestAllTypesProto3_MapStringNestedEnumEntry implements \Protobuf\Message {
     return "protobuf_test_messages.proto3.TestAllTypesProto3.MapStringNestedEnumEntry";
   }
 
+  public static function ParseFrom(string $input): ?TestAllTypesProto3_MapStringNestedEnumEntry {
+    $msg = new TestAllTypesProto3_MapStringNestedEnumEntry();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();
@@ -1912,6 +2083,15 @@ class TestAllTypesProto3_MapStringForeignEnumEntry implements \Protobuf\Message 
 
   public function MessageName(): string {
     return "protobuf_test_messages.proto3.TestAllTypesProto3.MapStringForeignEnumEntry";
+  }
+
+  public static function ParseFrom(string $input): ?TestAllTypesProto3_MapStringForeignEnumEntry {
+    $msg = new TestAllTypesProto3_MapStringForeignEnumEntry();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
   }
 
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
@@ -2412,6 +2592,15 @@ class TestAllTypesProto3 implements \Protobuf\Message {
 
   public function MessageName(): string {
     return "protobuf_test_messages.proto3.TestAllTypesProto3";
+  }
+
+  public static function ParseFrom(string $input): ?TestAllTypesProto3 {
+    $msg = new TestAllTypesProto3();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
   }
 
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
@@ -5291,6 +5480,15 @@ class ForeignMessage implements \Protobuf\Message {
     return "protobuf_test_messages.proto3.ForeignMessage";
   }
 
+  public static function ParseFrom(string $input): ?ForeignMessage {
+    $msg = new ForeignMessage();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();
@@ -5351,6 +5549,15 @@ class NullHypothesisProto3 implements \Protobuf\Message {
 
   public function MessageName(): string {
     return "protobuf_test_messages.proto3.NullHypothesisProto3";
+  }
+
+  public static function ParseFrom(string $input): ?NullHypothesisProto3 {
+    $msg = new NullHypothesisProto3();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
   }
 
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
@@ -5426,6 +5633,15 @@ class EnumOnlyProto3 implements \Protobuf\Message {
 
   public function MessageName(): string {
     return "protobuf_test_messages.proto3.EnumOnlyProto3";
+  }
+
+  public static function ParseFrom(string $input): ?EnumOnlyProto3 {
+    $msg = new EnumOnlyProto3();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
   }
 
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {

--- a/generated/google/protobuf/timestamp_proto.php
+++ b/generated/google/protobuf/timestamp_proto.php
@@ -22,6 +22,15 @@ class Timestamp implements \Protobuf\Message {
     return "google.protobuf.Timestamp";
   }
 
+  public static function ParseFrom(string $input): ?Timestamp {
+    $msg = new Timestamp();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();

--- a/generated/google/protobuf/type_proto.php
+++ b/generated/google/protobuf/type_proto.php
@@ -59,6 +59,15 @@ class Type implements \Protobuf\Message {
     return "google.protobuf.Type";
   }
 
+  public static function ParseFrom(string $input): ?Type {
+    $msg = new Type();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();
@@ -352,6 +361,15 @@ class Field implements \Protobuf\Message {
     return "google.protobuf.Field";
   }
 
+  public static function ParseFrom(string $input): ?Field {
+    $msg = new Field();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();
@@ -548,6 +566,15 @@ class pb_Enum implements \Protobuf\Message {
     return "google.protobuf.Enum";
   }
 
+  public static function ParseFrom(string $input): ?pb_Enum {
+    $msg = new pb_Enum();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();
@@ -699,6 +726,15 @@ class EnumValue implements \Protobuf\Message {
     return "google.protobuf.EnumValue";
   }
 
+  public static function ParseFrom(string $input): ?EnumValue {
+    $msg = new EnumValue();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();
@@ -800,6 +836,15 @@ class Option implements \Protobuf\Message {
 
   public function MessageName(): string {
     return "google.protobuf.Option";
+  }
+
+  public static function ParseFrom(string $input): ?Option {
+    $msg = new Option();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
   }
 
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {

--- a/generated/google/protobuf/wrappers_proto.php
+++ b/generated/google/protobuf/wrappers_proto.php
@@ -19,6 +19,15 @@ class DoubleValue implements \Protobuf\Message {
     return "google.protobuf.DoubleValue";
   }
 
+  public static function ParseFrom(string $input): ?DoubleValue {
+    $msg = new DoubleValue();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();
@@ -70,6 +79,15 @@ class FloatValue implements \Protobuf\Message {
 
   public function MessageName(): string {
     return "google.protobuf.FloatValue";
+  }
+
+  public static function ParseFrom(string $input): ?FloatValue {
+    $msg = new FloatValue();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
   }
 
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
@@ -125,6 +143,15 @@ class Int64Value implements \Protobuf\Message {
     return "google.protobuf.Int64Value";
   }
 
+  public static function ParseFrom(string $input): ?Int64Value {
+    $msg = new Int64Value();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();
@@ -176,6 +203,15 @@ class UInt64Value implements \Protobuf\Message {
 
   public function MessageName(): string {
     return "google.protobuf.UInt64Value";
+  }
+
+  public static function ParseFrom(string $input): ?UInt64Value {
+    $msg = new UInt64Value();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
   }
 
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
@@ -231,6 +267,15 @@ class Int32Value implements \Protobuf\Message {
     return "google.protobuf.Int32Value";
   }
 
+  public static function ParseFrom(string $input): ?Int32Value {
+    $msg = new Int32Value();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();
@@ -282,6 +327,15 @@ class UInt32Value implements \Protobuf\Message {
 
   public function MessageName(): string {
     return "google.protobuf.UInt32Value";
+  }
+
+  public static function ParseFrom(string $input): ?UInt32Value {
+    $msg = new UInt32Value();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
   }
 
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
@@ -337,6 +391,15 @@ class BoolValue implements \Protobuf\Message {
     return "google.protobuf.BoolValue";
   }
 
+  public static function ParseFrom(string $input): ?BoolValue {
+    $msg = new BoolValue();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();
@@ -390,6 +453,15 @@ class StringValue implements \Protobuf\Message {
     return "google.protobuf.StringValue";
   }
 
+  public static function ParseFrom(string $input): ?StringValue {
+    $msg = new StringValue();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();
@@ -441,6 +513,15 @@ class BytesValue implements \Protobuf\Message {
 
   public function MessageName(): string {
     return "google.protobuf.BytesValue";
+  }
+
+  public static function ParseFrom(string $input): ?BytesValue {
+    $msg = new BytesValue();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
   }
 
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {

--- a/generated/test/example1_proto.php
+++ b/generated/test/example1_proto.php
@@ -44,6 +44,15 @@ class example2 implements \Protobuf\Message {
     return "foo.bar.example2";
   }
 
+  public static function ParseFrom(string $input): ?example2 {
+    $msg = new example2();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();
@@ -201,6 +210,15 @@ class example1_example2 implements \Protobuf\Message {
     return "foo.bar.example1.example2";
   }
 
+  public static function ParseFrom(string $input): ?example1_example2 {
+    $msg = new example1_example2();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();
@@ -267,6 +285,15 @@ class example1_AmapEntry implements \Protobuf\Message {
 
   public function MessageName(): string {
     return "foo.bar.example1.AmapEntry";
+  }
+
+  public static function ParseFrom(string $input): ?example1_AmapEntry {
+    $msg = new example1_AmapEntry();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
   }
 
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
@@ -347,6 +374,15 @@ class example1_Amap2Entry implements \Protobuf\Message {
 
   public function MessageName(): string {
     return "foo.bar.example1.Amap2Entry";
+  }
+
+  public static function ParseFrom(string $input): ?example1_Amap2Entry {
+    $msg = new example1_Amap2Entry();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
   }
 
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
@@ -515,6 +551,15 @@ class example1 implements \Protobuf\Message {
 
   public function MessageName(): string {
     return "foo.bar.example1";
+  }
+
+  public static function ParseFrom(string $input): ?example1 {
+    $msg = new example1();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
   }
 
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {

--- a/generated/test/example2_proto.php
+++ b/generated/test/example2_proto.php
@@ -42,6 +42,15 @@ class example2 implements \Protobuf\Message {
     return "fiz.baz.example2";
   }
 
+  public static function ParseFrom(string $input): ?example2 {
+    $msg = new example2();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();
@@ -105,6 +114,15 @@ class refexample3 implements \Protobuf\Message {
 
   public function MessageName(): string {
     return "fiz.baz.refexample3";
+  }
+
+  public static function ParseFrom(string $input): ?refexample3 {
+    $msg = new refexample3();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
   }
 
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {

--- a/generated/test/example3_proto.php
+++ b/generated/test/example3_proto.php
@@ -18,6 +18,15 @@ class Donkey implements \Protobuf\Message {
     return "Donkey";
   }
 
+  public static function ParseFrom(string $input): ?Donkey {
+    $msg = new Donkey();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();
@@ -81,6 +90,15 @@ class Funky_Monkey implements \Protobuf\Message {
 
   public function MessageName(): string {
     return "Funky.Monkey";
+  }
+
+  public static function ParseFrom(string $input): ?Funky_Monkey {
+    $msg = new Funky_Monkey();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
   }
 
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
@@ -149,6 +167,15 @@ class Funky implements \Protobuf\Message {
 
   public function MessageName(): string {
     return "Funky";
+  }
+
+  public static function ParseFrom(string $input): ?Funky {
+    $msg = new Funky();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
   }
 
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {

--- a/generated/test/example4_proto.php
+++ b/generated/test/example4_proto.php
@@ -18,6 +18,15 @@ class pb_Class implements \Protobuf\Message {
     return "Class";
   }
 
+  public static function ParseFrom(string $input): ?pb_Class {
+    $msg = new pb_Class();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();
@@ -81,6 +90,15 @@ class pb_Interface implements \Protobuf\Message {
 
   public function MessageName(): string {
     return "Interface";
+  }
+
+  public static function ParseFrom(string $input): ?pb_Interface {
+    $msg = new pb_Interface();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
   }
 
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
@@ -156,6 +174,15 @@ class NotClass implements \Protobuf\Message {
 
   public function MessageName(): string {
     return "NotClass";
+  }
+
+  public static function ParseFrom(string $input): ?NotClass {
+    $msg = new NotClass();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
   }
 
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {

--- a/generated/test/exampleany_proto.php
+++ b/generated/test/exampleany_proto.php
@@ -18,6 +18,15 @@ class AnyTest implements \Protobuf\Message {
     return "AnyTest";
   }
 
+  public static function ParseFrom(string $input): ?AnyTest {
+    $msg = new AnyTest();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();

--- a/generated/test/proto2_ex1_proto.php
+++ b/generated/test/proto2_ex1_proto.php
@@ -65,6 +65,15 @@ class example1 implements \Protobuf\Message {
     return "bing.bong.example1";
   }
 
+  public static function ParseFrom(string $input): ?example1 {
+    $msg = new example1();
+    $e = \Protobuf\Unmarshal($input, $msg);
+    if (!$e->Ok()) {
+      return null;
+    }
+    return $msg;
+  }
+
   public function MergeFrom(\Protobuf\Internal\Decoder $d): void {
     while (!$d->isEOF()){
       list($fn, $wt) = $d->readTag();

--- a/protoc-gen-hack/plugin.go
+++ b/protoc-gen-hack/plugin.go
@@ -1411,6 +1411,17 @@ func writeDescriptor(w *writer, dp *desc.DescriptorProto, ns *Namespace, prefixN
 	w.p("}")
 	w.ln()
 
+	// helper: Create instantiated message from input bytes
+	w.p("public static function ParseFrom(string $input): ?%s {", name)
+	w.p("$msg = new %s();", name)
+	w.p("$e = \\Protobuf\\Unmarshal($input, $msg);")
+	w.p("if (!$e->Ok()) {")
+	w.p("return null;")
+	w.p("}")
+	w.p("return $msg;")
+	w.p("}")
+	w.ln()
+
 	// Now sort the fields by number.
 	sort.Slice(fields, func(i, j int) bool {
 		return fields[i].fd.GetNumber() < fields[j].fd.GetNumber()


### PR DESCRIPTION
Allows for:

	$msg = MesssageClass::ParseFrom($bytes);

which matches the Java-style syntax, where the left-hand-side of the function call expression is the instantiated object.