### PR TITLE
Rework the benchmarking logic

### DIFF
--- a/benchmark.sh
+++ b/benchmark.sh
@@ -1,12 +1,8 @@
 #!/bin/bash
 set -xeuo pipefail
-echo running benchmark harness...
-if [ $# -ge 1 ]; then
-  echo with repo auth
-  TMP=`mktemp -d`
-  hhvm --hphp -t hhbc --module=generated --module=lib --module=test --output-dir $TMP
-  hhvm -d hhvm.repo.authoritative=true -d hhvm.repo.central.path=$TMP/hhvm.hhbc test/test.php bench
-else
-  echo without repo auth
-  hhvm -d hhvm.perf_pid_map=1 test/test.php bench
-fi
+echo running benchmark harness with repo auth
+
+runs=${1:-}
+TMP=`mktemp -d`
+hhvm --hphp -t hhbc --module=generated --module=lib --module=test --output-dir $TMP
+hhvm -d hhvm.repo.authoritative=true -d hhvm.repo.central.path=$TMP/hhvm.hhbc test/test.php bench $runs

--- a/test/test.php
+++ b/test/test.php
@@ -19,7 +19,14 @@ function main(): void {
 
   $argv = HH\global_get('argv') as KeyedContainer<_, _>;
   if (count($argv) > 1 && $argv[1] == 'bench') {
-    bench();
+    $runs = 10000;
+    if (count($argv) > 2) {
+      $arg_runs = (int)$argv[2];
+      if ($arg_runs >= 0) {
+        $runs = $arg_runs;
+      }
+    }
+    bench($runs);
     exit(1);
   }
 


### PR DESCRIPTION
This PR forces testing in repo auth mode. This is because HHVM is optimized to run in this mode.
So measuring performance against other mode would introduce distortion in the measurements.

This PR also improves measurements by:
1. Warming up HHVM to ensure consistent measurements. The first run is usually an outlier as
there are some one-off initializations in the VM that would be included in it.
2. Compute the average and standard deviation after the runs so those can be easily measured when optimizing.

To be able to do 2, the infinite mode was removed, replaced by a large loop count instead.