### PR TITLE
Improve float/double writing logic

### DIFF
--- a/.hhconfig
+++ b/.hhconfig
@@ -1,2 +1,3 @@
 ignored_paths=["bazel-proto-hack"]
 assume_php=false
+allowed_fixme_codes_strict=2049,4107

--- a/lib/protobuf.php
+++ b/lib/protobuf.php
@@ -354,11 +354,19 @@ namespace Protobuf\Internal {
     }
 
     public function writeFloat(float $f): void {
-      $this->buf .= \pack('f', $f);
+      // TODO: Compute the position before growing the string.
+      // Unfortunately this crashes on HHVM 4.153.1 (but not on HHVM 4.164.0).
+      $this->buf .= "\x0\x0\x0\x0";
+      $pos = \strlen($this->buf) - 4;
+      /*HH_FIXME[4107]*//*HH_FIXME[2049]*/\HH\set_bytes_float32($this->buf, $pos, $f);
     }
 
     public function writeDouble(float $d): void {
-      $this->buf .= \pack('d', $d);
+      // TODO: Compute the position before growing the string.
+      // Unfortunately this crashes on HHVM 4.153.1 (but not on HHVM 4.164.0).
+      $this->buf .= "\x0\x0\x0\x0\x0\x0\x0\x0";
+      $pos = \strlen($this->buf) - 8;
+      /*HH_FIXME[4107]*//*HH_FIXME[2049]*/\HH\set_bytes_float64($this->buf, $pos, $d);
     }
 
     public function writeRaw(string $s): void {


### PR DESCRIPTION
The logic leverages some internal HHVM functions
to avoid calling the slower `pack` function.

This is a 3% perf improvement on the existing
benchmark, 7% improvement on a float heavy benchmark.

Unfortunately we have to settle for a slightly
less readable variant of the code due to a bug in
the 4.153.1 (LTS) version of HHVM.