### PR TITLE
Use strict equality for boolean conversion

### DIFF
--- a/lib/protobuf.php
+++ b/lib/protobuf.php
@@ -82,7 +82,7 @@ namespace Protobuf {
       return $b ? self::TRUE : self::FALSE;
     }
     public static function ToBool(Internal\bool_map_key_t $b): bool {
-      return $b == self::TRUE ? true : false;
+      return $b === self::TRUE;
     }
   }
 }


### PR DESCRIPTION
This was flagged by one of our internal linter and should be safe to use.

Also removed the spurious binary operator as the equality is enough.