### PR TITLE
Fix the Ubuntu CI

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,4 +1,4 @@
-name: Ubuntu 18.04 Tests
+name: Ubuntu Tests
 
 on:
   push:
@@ -13,30 +13,11 @@ concurrency:
 
 jobs:
   ubuntu_ci:
-    runs-on: ubuntu-18.04
+    runs-on: 'ubuntu-latest'
     steps:
-      - name: Adding HHVM repo
-        run: |
-          curl -fsSL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x058341c68fc8de6017d775a1b4112585d386eb94" | gpg --dearmor > hhvm-archive-keyring.gpg
-          sudo mv hhvm-archive-keyring.gpg /usr/share/keyrings
-          echo "deb [arch=amd64 signed-by=/usr/share/keyrings/hhvm-archive-keyring.gpg] https://dl.hhvm.com/ubuntu bionic main" | sudo tee /etc/apt/sources.list.d/hhvm.list
-      - name: Adding Bazel repo
-        run: |
-          curl -fsSL https://bazel.build/bazel-release.pub.gpg | gpg --dearmor >bazel-archive-keyring.gpg
-          sudo mv bazel-archive-keyring.gpg /usr/share/keyrings
-          echo "deb [arch=amd64 signed-by=/usr/share/keyrings/bazel-archive-keyring.gpg] https://storage.googleapis.com/bazel-apt stable jdk1.8" | sudo tee /etc/apt/sources.list.d/bazel.list
-      - name: Installing deps
-        run: |
-          sudo apt update
-          sudo apt install hhvm bazel
       - name: Checking out
         uses: actions/checkout@v3
-      - name: Running the type checker
-        run: hh_client .
+      - name: Building image
+        run: docker build -t hhvm-test -f ci/Dockerfile .
       - name: Running tests
-        # TODO: Replace those with //... once //:typechecker_test is fixed.
-        run: |
-          bazel test //:gen_test
-          bazel test //:library_test
-          bazel test //:integration_test
-          bazel test //:conformance_test
+        run: docker run -v .:/source -w /source hhvm-test:latest ci/run_tests.sh

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,0 +1,5 @@
+FROM hhvm/hhvm:4.153-latest
+
+RUN curl -fsSL https://bazel.build/bazel-release.pub.gpg | gpg --dearmor > /usr/share/keyrings/bazel-archive-keyring.gpg
+RUN echo "deb [arch=amd64 signed-by=/usr/share/keyrings/bazel-archive-keyring.gpg] https://storage.googleapis.com/bazel-apt stable jdk1.8" > /etc/apt/sources.list.d/bazel.list
+RUN apt update && apt install -y bazel

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -xe
+
+echo "Running the typechecker"
+hh_client .
+
+echo "Running other tests"
+# TODO: Replace those with //... once //:typechecker_test is fixed.
+bazel test //:gen_test
+bazel test //:library_test
+bazel test //:integration_test
+bazel test //:conformance_test


### PR DESCRIPTION
The `ubuntu-18.04` image has been unsupported for more than a year and there are no workers on GitHub that runs it. This means that our CI just waits for one worker and times out.

The solution is to switch to a custom Docker image based on the HHVM public images and move all the tests run into the new image. To avoid spinning multiple containers (and recomputing some of the cached bazel actions), all tests were moved into a new script `ci/run_tests.sh`.