### PR TITLE
Check formatting of Hack + go code in our CI

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -2,4 +2,4 @@ FROM hhvm/hhvm:4.153-latest
 
 RUN curl -fsSL https://bazel.build/bazel-release.pub.gpg | gpg --dearmor > /usr/share/keyrings/bazel-archive-keyring.gpg
 RUN echo "deb [arch=amd64 signed-by=/usr/share/keyrings/bazel-archive-keyring.gpg] https://storage.googleapis.com/bazel-apt stable jdk1.8" > /etc/apt/sources.list.d/bazel.list
-RUN apt update && apt install -y bazel
+RUN apt update && apt install -y bazel golang

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -1,6 +1,30 @@
 #!/bin/sh
 
+sanity_check=$(git diff-index HEAD)
+if [ -n "$sanity_check" ]; then
+  echo "There is already a \`git diff\`!!\nBailing out as we can't detect any formatting change"
+  exit 1
+fi
+
 set -xe
+
+echo "Checking go fmt"
+go fmt protoc-gen-hack/*.go
+if [ -n "$(git diff-index HEAD)" ]; then
+  echo "Please run and commit the result of:\n  go fmt protoc-gen-hack/*.go"
+  exit 1
+fi
+
+echo "Checking hackfmt"
+FILES=`find . | grep -E "\.(php|hack)$" | grep -v \.swp | grep -v '^./generated/.*'`
+for i in $FILES
+do
+  hackfmt -i $i
+  if [ -n "$(git diff-index HEAD)" ]; then
+    echo "Please run and commit the result of:\n  hackfmt -i $i"
+    exit 1
+  fi
+done
 
 echo "Running the typechecker"
 hh_client .

--- a/conformance/conformance.php
+++ b/conformance/conformance.php
@@ -152,16 +152,14 @@ function conformance(ConformanceRequest $creq): ConformanceResponse {
     $payload = $creq->payload->json_payload;
     $wfi = WireFormat::JSON;
   } else {
-    $cresp->result = new ConformanceResponse_result_skipped(
-      "unsupported input type",
-    );
+    $cresp->result =
+      new ConformanceResponse_result_skipped("unsupported input type");
     return $cresp;
   }
   $wfo = $creq->requested_output_format;
   if ($wfo != WireFormat::PROTOBUF && $wfo != WireFormat::JSON) {
-    $cresp->result = new ConformanceResponse_result_skipped(
-      "unsupported output type",
-    );
+    $cresp->result =
+      new ConformanceResponse_result_skipped("unsupported output type");
     return $cresp;
   }
   $r = remarshal($tm, $payload, $wfi, $wfo);

--- a/hackformat.sh
+++ b/hackformat.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-FILES=`find . | grep \.php | grep -v \.swp | grep -v '^./generated/.*'`
-for i in $FILES
-do
-  echo formatting $i
-  hackfmt -i $i
-done

--- a/lib/grpc.php
+++ b/lib/grpc.php
@@ -283,9 +283,8 @@ namespace Grpc {
     $fq = \ltrim($fq, '/');
     $parts = \explode('/', $fq, 2);
     if (\count($parts) < 2) {
-      return ResultE(
-        Errorf("invalid fully qualified gRPC method name '%s'", $fq),
-      );
+      return
+        ResultE(Errorf("invalid fully qualified gRPC method name '%s'", $fq));
     }
     return ResultV(tuple($parts[0], $parts[1]));
   }

--- a/lib/protobuf.php
+++ b/lib/protobuf.php
@@ -95,9 +95,8 @@ namespace Protobuf\Internal {
 
   function AssertEndiannessAndIntSize(): void {
     if (\PHP_INT_SIZE != 8) {
-      throw new \ProtobufException(
-        "unsupported PHP_INT_SIZE size: ".\PHP_INT_SIZE,
-      );
+      throw
+        new \ProtobufException("unsupported PHP_INT_SIZE size: ".\PHP_INT_SIZE);
     }
     $end = \unpack('l', "\x70\x10\xF0\x00")[1];
     if ($end !== 15732848) {
@@ -126,9 +125,8 @@ namespace Protobuf\Internal {
       $shift = 0;
       while (true) {
         if ($this->isEOF()) {
-          throw new \ProtobufException(
-            "buffer overrun while reading varint-128",
-          );
+          throw
+            new \ProtobufException("buffer overrun while reading varint-128");
         }
         $c = \ord($this->buf[$this->offset]);
         $this->offset++;
@@ -216,9 +214,8 @@ namespace Protobuf\Internal {
       }
       $noff = $this->offset + $size;
       if ($noff > $this->len) {
-        throw new \ProtobufException(
-          "buffer overrun while reading raw: ".$size,
-        );
+        throw
+          new \ProtobufException("buffer overrun while reading raw: ".$size);
       }
       $ss = \substr($this->buf, $this->offset, $size);
       $this->offset = $noff;
@@ -229,9 +226,8 @@ namespace Protobuf\Internal {
       $size = $this->readVarint();
       $noff = $this->offset + $size;
       if ($noff > $this->len) {
-        throw new \ProtobufException(
-          "buffer overrun while reading buffer: ".$size,
-        );
+        throw
+          new \ProtobufException("buffer overrun while reading buffer: ".$size);
       }
       $buf = new Decoder($this->buf, $this->offset, $noff, new Encoder());
       $this->offset = $noff;
@@ -431,12 +427,10 @@ namespace Protobuf\Internal {
 
     public function __construct(int $opt) {
       $this->pretty_print = (bool)($opt & \Protobuf\JsonEncode::PRETTY_PRINT);
-      $this->emit_default_values = (bool)(
-        $opt & \Protobuf\JsonEncode::EMIT_DEFAULT_VALUES
-      );
-      $this->preserve_names = (bool)(
-        $opt & \Protobuf\JsonEncode::PRESERVE_NAMES
-      );
+      $this->emit_default_values =
+        (bool)($opt & \Protobuf\JsonEncode::EMIT_DEFAULT_VALUES);
+      $this->preserve_names =
+        (bool)($opt & \Protobuf\JsonEncode::PRESERVE_NAMES);
       $this->enums_as_ints = (bool)($opt & \Protobuf\JsonEncode::ENUMS_AS_INTS);
     }
   }
@@ -537,10 +531,8 @@ namespace Protobuf\Internal {
       bool $emit_default,
     ): void {
       if ($value != 0 || $emit_default || $this->o->emit_default_values) {
-        $this->a[$this->o->preserve_names ? $oname : $cname] = \sprintf(
-          '%d',
-          $value,
-        );
+        $this->a[$this->o->preserve_names ? $oname : $cname] =
+          \sprintf('%d', $value);
       }
     }
 
@@ -579,10 +571,8 @@ namespace Protobuf\Internal {
       bool $emit_default,
     ): void {
       if ($value != 0 || $emit_default || $this->o->emit_default_values) {
-        $this->a[$this->o->preserve_names ? $oname : $cname] = \sprintf(
-          '%u',
-          $value,
-        );
+        $this->a[$this->o->preserve_names ? $oname : $cname] =
+          \sprintf('%u', $value);
       }
     }
 
@@ -829,13 +819,18 @@ namespace Protobuf\Internal {
         return null;
       }
       $error_data = null;
-      $data = \json_decode_with_error($str, inout $error_data, true, 512, \JSON_FB_HACK_ARRAYS);
+      $data = \json_decode_with_error(
+        $str,
+        inout $error_data,
+        true,
+        512,
+        \JSON_FB_HACK_ARRAYS,
+      );
       if ($data !== null) {
         return $data;
       }
-      throw new \ProtobufException(
-        "json_decode failed; ".($error_data[1] ?? ''),
-      );
+      throw
+        new \ProtobufException("json_decode failed; ".($error_data[1] ?? ''));
     }
 
     public static function readObject(mixed $m): dict<string, mixed> {
@@ -846,9 +841,8 @@ namespace Protobuf\Internal {
         }
         return $ret;
       }
-      throw new \ProtobufException(
-        \sprintf("expected dict got %s", \gettype($m)),
-      );
+      throw
+        new \ProtobufException(\sprintf("expected dict got %s", \gettype($m)));
     }
 
     public static function readList(mixed $m): vec<mixed> {
@@ -861,9 +855,8 @@ namespace Protobuf\Internal {
         }
         return $ret;
       }
-      throw new \ProtobufException(
-        \sprintf("expected vec got %s", \gettype($m)),
-      );
+      throw
+        new \ProtobufException(\sprintf("expected vec got %s", \gettype($m)));
     }
 
     public static function readBytes(mixed $m): string {
@@ -946,9 +939,8 @@ namespace Protobuf\Internal {
         }
         return (int)$m;
       }
-      throw new \ProtobufException(
-        \sprintf("expected int got %s", \gettype($m)),
-      );
+      throw
+        new \ProtobufException(\sprintf("expected int got %s", \gettype($m)));
     }
 
     public static function readInt32Signed(mixed $m): int {
@@ -989,9 +981,8 @@ namespace Protobuf\Internal {
       if (\is_numeric($m)) {
         return (float)$m;
       }
-      throw new \ProtobufException(
-        \sprintf("expected float got %s", \gettype($m)),
-      );
+      throw
+        new \ProtobufException(\sprintf("expected float got %s", \gettype($m)));
     }
 
     public static function readBool(mixed $m): bool {
@@ -999,9 +990,8 @@ namespace Protobuf\Internal {
         return false;
       if ($m is bool)
         return $m;
-      throw new \ProtobufException(
-        \sprintf("expected bool got %s", \gettype($m)),
-      );
+      throw
+        new \ProtobufException(\sprintf("expected bool got %s", \gettype($m)));
     }
 
     public static function readBoolMapKey(mixed $m): bool_map_key_t {

--- a/protoc-gen-hack/namespace.go
+++ b/protoc-gen-hack/namespace.go
@@ -146,10 +146,10 @@ func mustFullyQualified(fqn string) {
 }
 
 // Find is where the magic happens. It takes a fully qualified proto name
-//   e.g. ".foo.bar.baz"
+// e.g. ".foo.bar.baz"
 // resolves it to a named entity and returns the proto name split at the
 // namespace boundary.
-//   e.g. ".foo" "bar.baz"
+// e.g. ".foo" "bar.baz"
 // and also returns the descriptor.
 func (n *Namespace) FindFullyQualifiedName(fqn string) (string, string, interface{}) {
 	mustFullyQualified(fqn)

--- a/test/test_suite.php
+++ b/test/test_suite.php
@@ -244,7 +244,10 @@ class Context implements \Grpc\Context {
 function testOptionalProto3(): void {
   echo "Testing empty optional proto3 proto: ";
   $msg = new \baz\optional_proto3();
-  Protobuf\Unmarshal(file_get_contents('generated/test/empty_optional_proto3.pb.bin'), $msg);
+  Protobuf\Unmarshal(
+    file_get_contents('generated/test/empty_optional_proto3.pb.bin'),
+    $msg,
+  );
   a($msg->getAdouble(), 0., 'adouble should be set to default value');
   a($msg->hasAdouble(), false, 'adouble shoult not be set');
   a($msg->getAint64(), 0, 'aint64 should be set to default value');
@@ -267,7 +270,10 @@ function testOptionalProto3(): void {
 
   echo("Testing optional proto3 proto with only default values: ");
   $msg = new \baz\optional_proto3();
-  Protobuf\Unmarshal(file_get_contents('generated/test/default_optional_proto3.pb.bin'), $msg);
+  Protobuf\Unmarshal(
+    file_get_contents('generated/test/default_optional_proto3.pb.bin'),
+    $msg,
+  );
   a($msg->getAdouble(), 0., 'adouble should be set to default value');
   a($msg->hasAdouble(), true, 'adouble should be set');
   a($msg->getAint64(), 0, 'aint64 should be set to default value');
@@ -290,7 +296,10 @@ function testOptionalProto3(): void {
 
   echo("Testing optional proto3 proto with only custom non-default values: ");
   $msg = new \baz\optional_proto3();
-  Protobuf\Unmarshal(file_get_contents('generated/test/custom_optional_proto3.pb.bin'), $msg);
+  Protobuf\Unmarshal(
+    file_get_contents('generated/test/custom_optional_proto3.pb.bin'),
+    $msg,
+  );
   a($msg->getAdouble(), 3.14, 'adouble should be set');
   a($msg->hasAdouble(), true, 'adouble should be set');
   a($msg->getAint64(), 1234, 'aint64 should be set');
@@ -313,7 +322,10 @@ function testOptionalProto3(): void {
 
   echo("Testing JSON decoding: ");
   $msg = new \baz\optional_proto3();
-  Protobuf\UnmarshalJson(file_get_contents('test/mixed_optional_proto3.pb.json'), $msg);
+  Protobuf\UnmarshalJson(
+    file_get_contents('test/mixed_optional_proto3.pb.json'),
+    $msg,
+  );
   a($msg->getAdouble(), 3.14, 'adouble should be set');
   a($msg->hasAdouble(), true, 'adouble should be set');
   a($msg->getAint64(), 1234, 'aint64 should be set');


### PR DESCRIPTION
There was a script to check that hackfmt was ran
at the root of the repository. It seemed more
useful to fold the logic into the CI so
it is automatically checked.

The formatting changes are whitespace only.