### PR TITLE
Set the release automatically

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,2 +1,3 @@
+build --stamp --workspace_status_command="$PWD/workspace_status"
 test --test_output=errors
 common --experimental_ui_max_stdouterr_bytes=100000000

--- a/BUILD
+++ b/BUILD
@@ -24,7 +24,7 @@ go_binary(
     ],
     out = "protoc-gen-hack",
     visibility = ["//visibility:public"],
-    x_defs = {"version": "8.0.0"},
+    x_defs = {"version": "{RELEASE_VERSION}"},
     deps = [
         ":opt_go_proto",
         "@com_github_golang_protobuf//proto:go_default_library",

--- a/workspace_status
+++ b/workspace_status
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# This sets some variables for our releases.
+# See https://github.com/bazelbuild/bazel/blob/master/tools/buildstamp/get_workspace_status
+
+git_rev=$(git describe --tags)
+if [[ $? != 0 ]];
+then
+  exit 1
+fi
+
+echo "RELEASE_VERSION ${git_rev}"


### PR DESCRIPTION
The version was hard-coded to 8.0.0 and never updated.

This PR leverages bazel's stamping to automatically generate it from git in workspace_status and pass it to the go binary:
https://github.com/bazelbuild/rules_go/blob/master/docs/go/core/defines_and_stamping.md#defines-and-stamping