### PR TITLE
Fetch tags in CI

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           fetch-tags: True
           fetch-depth: 0
-      - run: git tags -l
+      - run: git tag -l
       - run: git describe --tags
       - name: Building image
         run: docker build -t hhvm-test -f ci/Dockerfile .


### PR DESCRIPTION
Attempts to fix the CI failure in #29 . The `workspace_status` script for Bazel was failing because git tags weren't being checkout out, so it couldn't generate the release tag version.