### PR TITLE
Fix linting to comply with hhast splinter rules

### DIFF
--- a/lib/grpc.php
+++ b/lib/grpc.php
@@ -4,7 +4,7 @@ namespace Grpc {
   use type \Errors\{Error, Result};
   use function \Errors\{ResultE, ResultV};
 
-  use \Protobuf\Message;
+  use type \Protobuf\Message;
 
 
   newtype Code as int = int;


### PR DESCRIPTION
Modified `lib/grpc.php` to comply with splinter rules in webapp. This change is no-op otherwise. Tested by building a new binary, running existing tests to ensure this change is safe.