### PR TITLE
Better support for CopyFrom with optionals

### DIFF
--- a/generated/google/protobuf/compiler/plugin_proto.php
+++ b/generated/google/protobuf/compiler/plugin_proto.php
@@ -211,16 +211,16 @@ class Version implements \Protobuf\Message {
       return \Errors\Errorf('CopyFrom failed: incorrect type received: %s', $o->MessageName());
     }
     if ($o->hasMajor()) {
-      $this->major = $o->major;
+      $this->setMajor($o->getMajor());
     }
     if ($o->hasMinor()) {
-      $this->minor = $o->minor;
+      $this->setMinor($o->getMinor());
     }
     if ($o->hasPatch()) {
-      $this->patch = $o->patch;
+      $this->setPatch($o->getPatch());
     }
     if ($o->hasSuffix()) {
-      $this->suffix = $o->suffix;
+      $this->setSuffix($o->getSuffix());
     }
     $this->XXX_unrecognized = $o->XXX_unrecognized;
     return \Errors\Ok();
@@ -407,7 +407,7 @@ class CodeGeneratorRequest implements \Protobuf\Message {
     }
     $this->file_to_generate = $o->file_to_generate;
     if ($o->hasParameter()) {
-      $this->parameter = $o->parameter;
+      $this->setParameter($o->getParameter());
     }
     $tmp = $o->compiler_version;
     if ($tmp is nonnull) {
@@ -670,13 +670,13 @@ class CodeGeneratorResponse_File implements \Protobuf\Message {
       return \Errors\Errorf('CopyFrom failed: incorrect type received: %s', $o->MessageName());
     }
     if ($o->hasName()) {
-      $this->name = $o->name;
+      $this->setName($o->getName());
     }
     if ($o->hasInsertionPoint()) {
-      $this->insertion_point = $o->insertion_point;
+      $this->setInsertionPoint($o->getInsertionPoint());
     }
     if ($o->hasContent()) {
-      $this->content = $o->content;
+      $this->setContent($o->getContent());
     }
     $tmp = $o->generated_code_info;
     if ($tmp is nonnull) {
@@ -843,10 +843,10 @@ class CodeGeneratorResponse implements \Protobuf\Message {
       return \Errors\Errorf('CopyFrom failed: incorrect type received: %s', $o->MessageName());
     }
     if ($o->hasError()) {
-      $this->error = $o->error;
+      $this->setError($o->getError());
     }
     if ($o->hasSupportedFeatures()) {
-      $this->supported_features = $o->supported_features;
+      $this->setSupportedFeatures($o->getSupportedFeatures());
     }
     foreach ($o->file as $v) {
       $nv = new \google\protobuf\compiler\CodeGeneratorResponse_File();

--- a/generated/google/protobuf/descriptor_proto.php
+++ b/generated/google/protobuf/descriptor_proto.php
@@ -502,10 +502,10 @@ class FileDescriptorProto implements \Protobuf\Message {
       return \Errors\Errorf('CopyFrom failed: incorrect type received: %s', $o->MessageName());
     }
     if ($o->hasName()) {
-      $this->name = $o->name;
+      $this->setName($o->getName());
     }
     if ($o->hasPackage()) {
-      $this->package = $o->package;
+      $this->setPackage($o->getPackage());
     }
     $this->dependency = $o->dependency;
     foreach ($o->message_type as $v) {
@@ -547,7 +547,7 @@ class FileDescriptorProto implements \Protobuf\Message {
     $this->public_dependency = $o->public_dependency;
     $this->weak_dependency = $o->weak_dependency;
     if ($o->hasSyntax()) {
-      $this->syntax = $o->syntax;
+      $this->setSyntax($o->getSyntax());
     }
     $this->XXX_unrecognized = $o->XXX_unrecognized;
     return \Errors\Ok();
@@ -734,10 +734,10 @@ class DescriptorProto_ExtensionRange implements \Protobuf\Message {
       return \Errors\Errorf('CopyFrom failed: incorrect type received: %s', $o->MessageName());
     }
     if ($o->hasStart()) {
-      $this->start = $o->start;
+      $this->setStart($o->getStart());
     }
     if ($o->hasEnd()) {
-      $this->end = $o->end;
+      $this->setEnd($o->getEnd());
     }
     $tmp = $o->options;
     if ($tmp is nonnull) {
@@ -883,10 +883,10 @@ class DescriptorProto_ReservedRange implements \Protobuf\Message {
       return \Errors\Errorf('CopyFrom failed: incorrect type received: %s', $o->MessageName());
     }
     if ($o->hasStart()) {
-      $this->start = $o->start;
+      $this->setStart($o->getStart());
     }
     if ($o->hasEnd()) {
-      $this->end = $o->end;
+      $this->setEnd($o->getEnd());
     }
     $this->XXX_unrecognized = $o->XXX_unrecognized;
     return \Errors\Ok();
@@ -1198,7 +1198,7 @@ class DescriptorProto implements \Protobuf\Message {
       return \Errors\Errorf('CopyFrom failed: incorrect type received: %s', $o->MessageName());
     }
     if ($o->hasName()) {
-      $this->name = $o->name;
+      $this->setName($o->getName());
     }
     foreach ($o->field as $v) {
       $nv = new \google\protobuf\FieldDescriptorProto();
@@ -1919,25 +1919,25 @@ class FieldDescriptorProto implements \Protobuf\Message {
       return \Errors\Errorf('CopyFrom failed: incorrect type received: %s', $o->MessageName());
     }
     if ($o->hasName()) {
-      $this->name = $o->name;
+      $this->setName($o->getName());
     }
     if ($o->hasExtendee()) {
-      $this->extendee = $o->extendee;
+      $this->setExtendee($o->getExtendee());
     }
     if ($o->hasNumber()) {
-      $this->number = $o->number;
+      $this->setNumber($o->getNumber());
     }
     if ($o->hasLabel()) {
-      $this->label = $o->label;
+      $this->setLabel($o->getLabel());
     }
     if ($o->hasType()) {
-      $this->type = $o->type;
+      $this->setType($o->getType());
     }
     if ($o->hasTypeName()) {
-      $this->type_name = $o->type_name;
+      $this->setTypeName($o->getTypeName());
     }
     if ($o->hasDefaultValue()) {
-      $this->default_value = $o->default_value;
+      $this->setDefaultValue($o->getDefaultValue());
     }
     $tmp = $o->options;
     if ($tmp is nonnull) {
@@ -1948,13 +1948,13 @@ class FieldDescriptorProto implements \Protobuf\Message {
       $this->setOptions(null);
     }
     if ($o->hasOneofIndex()) {
-      $this->oneof_index = $o->oneof_index;
+      $this->setOneofIndex($o->getOneofIndex());
     }
     if ($o->hasJsonName()) {
-      $this->json_name = $o->json_name;
+      $this->setJsonName($o->getJsonName());
     }
     if ($o->hasProto3Optional()) {
-      $this->proto3_optional = $o->proto3_optional;
+      $this->setProto3Optional($o->getProto3Optional());
     }
     $this->XXX_unrecognized = $o->XXX_unrecognized;
     return \Errors\Ok();
@@ -2103,7 +2103,7 @@ class OneofDescriptorProto implements \Protobuf\Message {
       return \Errors\Errorf('CopyFrom failed: incorrect type received: %s', $o->MessageName());
     }
     if ($o->hasName()) {
-      $this->name = $o->name;
+      $this->setName($o->getName());
     }
     $tmp = $o->options;
     if ($tmp is nonnull) {
@@ -2249,10 +2249,10 @@ class EnumDescriptorProto_EnumReservedRange implements \Protobuf\Message {
       return \Errors\Errorf('CopyFrom failed: incorrect type received: %s', $o->MessageName());
     }
     if ($o->hasStart()) {
-      $this->start = $o->start;
+      $this->setStart($o->getStart());
     }
     if ($o->hasEnd()) {
-      $this->end = $o->end;
+      $this->setEnd($o->getEnd());
     }
     $this->XXX_unrecognized = $o->XXX_unrecognized;
     return \Errors\Ok();
@@ -2459,7 +2459,7 @@ class EnumDescriptorProto implements \Protobuf\Message {
       return \Errors\Errorf('CopyFrom failed: incorrect type received: %s', $o->MessageName());
     }
     if ($o->hasName()) {
-      $this->name = $o->name;
+      $this->setName($o->getName());
     }
     foreach ($o->value as $v) {
       $nv = new \google\protobuf\EnumValueDescriptorProto();
@@ -2665,10 +2665,10 @@ class EnumValueDescriptorProto implements \Protobuf\Message {
       return \Errors\Errorf('CopyFrom failed: incorrect type received: %s', $o->MessageName());
     }
     if ($o->hasName()) {
-      $this->name = $o->name;
+      $this->setName($o->getName());
     }
     if ($o->hasNumber()) {
-      $this->number = $o->number;
+      $this->setNumber($o->getNumber());
     }
     $tmp = $o->options;
     if ($tmp is nonnull) {
@@ -2846,7 +2846,7 @@ class ServiceDescriptorProto implements \Protobuf\Message {
       return \Errors\Errorf('CopyFrom failed: incorrect type received: %s', $o->MessageName());
     }
     if ($o->hasName()) {
-      $this->name = $o->name;
+      $this->setName($o->getName());
     }
     foreach ($o->method as $v) {
       $nv = new \google\protobuf\MethodDescriptorProto();
@@ -3160,13 +3160,13 @@ class MethodDescriptorProto implements \Protobuf\Message {
       return \Errors\Errorf('CopyFrom failed: incorrect type received: %s', $o->MessageName());
     }
     if ($o->hasName()) {
-      $this->name = $o->name;
+      $this->setName($o->getName());
     }
     if ($o->hasInputType()) {
-      $this->input_type = $o->input_type;
+      $this->setInputType($o->getInputType());
     }
     if ($o->hasOutputType()) {
-      $this->output_type = $o->output_type;
+      $this->setOutputType($o->getOutputType());
     }
     $tmp = $o->options;
     if ($tmp is nonnull) {
@@ -3177,10 +3177,10 @@ class MethodDescriptorProto implements \Protobuf\Message {
       $this->setOptions(null);
     }
     if ($o->hasClientStreaming()) {
-      $this->client_streaming = $o->client_streaming;
+      $this->setClientStreaming($o->getClientStreaming());
     }
     if ($o->hasServerStreaming()) {
-      $this->server_streaming = $o->server_streaming;
+      $this->setServerStreaming($o->getServerStreaming());
     }
     $this->XXX_unrecognized = $o->XXX_unrecognized;
     return \Errors\Ok();
@@ -4051,64 +4051,64 @@ class FileOptions implements \Protobuf\Message {
       return \Errors\Errorf('CopyFrom failed: incorrect type received: %s', $o->MessageName());
     }
     if ($o->hasJavaPackage()) {
-      $this->java_package = $o->java_package;
+      $this->setJavaPackage($o->getJavaPackage());
     }
     if ($o->hasJavaOuterClassname()) {
-      $this->java_outer_classname = $o->java_outer_classname;
+      $this->setJavaOuterClassname($o->getJavaOuterClassname());
     }
     if ($o->hasOptimizeFor()) {
-      $this->optimize_for = $o->optimize_for;
+      $this->setOptimizeFor($o->getOptimizeFor());
     }
     if ($o->hasJavaMultipleFiles()) {
-      $this->java_multiple_files = $o->java_multiple_files;
+      $this->setJavaMultipleFiles($o->getJavaMultipleFiles());
     }
     if ($o->hasGoPackage()) {
-      $this->go_package = $o->go_package;
+      $this->setGoPackage($o->getGoPackage());
     }
     if ($o->hasCcGenericServices()) {
-      $this->cc_generic_services = $o->cc_generic_services;
+      $this->setCcGenericServices($o->getCcGenericServices());
     }
     if ($o->hasJavaGenericServices()) {
-      $this->java_generic_services = $o->java_generic_services;
+      $this->setJavaGenericServices($o->getJavaGenericServices());
     }
     if ($o->hasPyGenericServices()) {
-      $this->py_generic_services = $o->py_generic_services;
+      $this->setPyGenericServices($o->getPyGenericServices());
     }
     if ($o->hasJavaGenerateEqualsAndHash()) {
-      $this->java_generate_equals_and_hash = $o->java_generate_equals_and_hash;
+      $this->setJavaGenerateEqualsAndHash($o->getJavaGenerateEqualsAndHash());
     }
     if ($o->hasDeprecated()) {
-      $this->deprecated = $o->deprecated;
+      $this->setDeprecated($o->getDeprecated());
     }
     if ($o->hasJavaStringCheckUtf8()) {
-      $this->java_string_check_utf8 = $o->java_string_check_utf8;
+      $this->setJavaStringCheckUtf8($o->getJavaStringCheckUtf8());
     }
     if ($o->hasCcEnableArenas()) {
-      $this->cc_enable_arenas = $o->cc_enable_arenas;
+      $this->setCcEnableArenas($o->getCcEnableArenas());
     }
     if ($o->hasObjcClassPrefix()) {
-      $this->objc_class_prefix = $o->objc_class_prefix;
+      $this->setObjcClassPrefix($o->getObjcClassPrefix());
     }
     if ($o->hasCsharpNamespace()) {
-      $this->csharp_namespace = $o->csharp_namespace;
+      $this->setCsharpNamespace($o->getCsharpNamespace());
     }
     if ($o->hasSwiftPrefix()) {
-      $this->swift_prefix = $o->swift_prefix;
+      $this->setSwiftPrefix($o->getSwiftPrefix());
     }
     if ($o->hasPhpClassPrefix()) {
-      $this->php_class_prefix = $o->php_class_prefix;
+      $this->setPhpClassPrefix($o->getPhpClassPrefix());
     }
     if ($o->hasPhpNamespace()) {
-      $this->php_namespace = $o->php_namespace;
+      $this->setPhpNamespace($o->getPhpNamespace());
     }
     if ($o->hasPhpGenericServices()) {
-      $this->php_generic_services = $o->php_generic_services;
+      $this->setPhpGenericServices($o->getPhpGenericServices());
     }
     if ($o->hasPhpMetadataNamespace()) {
-      $this->php_metadata_namespace = $o->php_metadata_namespace;
+      $this->setPhpMetadataNamespace($o->getPhpMetadataNamespace());
     }
     if ($o->hasRubyPackage()) {
-      $this->ruby_package = $o->ruby_package;
+      $this->setRubyPackage($o->getRubyPackage());
     }
     foreach ($o->uninterpreted_option as $v) {
       $nv = new \google\protobuf\UninterpretedOption();
@@ -4348,16 +4348,16 @@ class MessageOptions implements \Protobuf\Message {
       return \Errors\Errorf('CopyFrom failed: incorrect type received: %s', $o->MessageName());
     }
     if ($o->hasMessageSetWireFormat()) {
-      $this->message_set_wire_format = $o->message_set_wire_format;
+      $this->setMessageSetWireFormat($o->getMessageSetWireFormat());
     }
     if ($o->hasNoStandardDescriptorAccessor()) {
-      $this->no_standard_descriptor_accessor = $o->no_standard_descriptor_accessor;
+      $this->setNoStandardDescriptorAccessor($o->getNoStandardDescriptorAccessor());
     }
     if ($o->hasDeprecated()) {
-      $this->deprecated = $o->deprecated;
+      $this->setDeprecated($o->getDeprecated());
     }
     if ($o->hasMapEntry()) {
-      $this->map_entry = $o->map_entry;
+      $this->setMapEntry($o->getMapEntry());
     }
     foreach ($o->uninterpreted_option as $v) {
       $nv = new \google\protobuf\UninterpretedOption();
@@ -4767,25 +4767,25 @@ class FieldOptions implements \Protobuf\Message {
       return \Errors\Errorf('CopyFrom failed: incorrect type received: %s', $o->MessageName());
     }
     if ($o->hasCtype()) {
-      $this->ctype = $o->ctype;
+      $this->setCtype($o->getCtype());
     }
     if ($o->hasPacked()) {
-      $this->packed = $o->packed;
+      $this->setPacked($o->getPacked());
     }
     if ($o->hasDeprecated()) {
-      $this->deprecated = $o->deprecated;
+      $this->setDeprecated($o->getDeprecated());
     }
     if ($o->hasLazy()) {
-      $this->lazy = $o->lazy;
+      $this->setLazy($o->getLazy());
     }
     if ($o->hasJstype()) {
-      $this->jstype = $o->jstype;
+      $this->setJstype($o->getJstype());
     }
     if ($o->hasWeak()) {
-      $this->weak = $o->weak;
+      $this->setWeak($o->getWeak());
     }
     if ($o->hasUnverifiedLazy()) {
-      $this->unverified_lazy = $o->unverified_lazy;
+      $this->setUnverifiedLazy($o->getUnverifiedLazy());
     }
     foreach ($o->uninterpreted_option as $v) {
       $nv = new \google\protobuf\UninterpretedOption();
@@ -5034,10 +5034,10 @@ class EnumOptions implements \Protobuf\Message {
       return \Errors\Errorf('CopyFrom failed: incorrect type received: %s', $o->MessageName());
     }
     if ($o->hasAllowAlias()) {
-      $this->allow_alias = $o->allow_alias;
+      $this->setAllowAlias($o->getAllowAlias());
     }
     if ($o->hasDeprecated()) {
-      $this->deprecated = $o->deprecated;
+      $this->setDeprecated($o->getDeprecated());
     }
     foreach ($o->uninterpreted_option as $v) {
       $nv = new \google\protobuf\UninterpretedOption();
@@ -5163,7 +5163,7 @@ class EnumValueOptions implements \Protobuf\Message {
       return \Errors\Errorf('CopyFrom failed: incorrect type received: %s', $o->MessageName());
     }
     if ($o->hasDeprecated()) {
-      $this->deprecated = $o->deprecated;
+      $this->setDeprecated($o->getDeprecated());
     }
     foreach ($o->uninterpreted_option as $v) {
       $nv = new \google\protobuf\UninterpretedOption();
@@ -5289,7 +5289,7 @@ class ServiceOptions implements \Protobuf\Message {
       return \Errors\Errorf('CopyFrom failed: incorrect type received: %s', $o->MessageName());
     }
     if ($o->hasDeprecated()) {
-      $this->deprecated = $o->deprecated;
+      $this->setDeprecated($o->getDeprecated());
     }
     foreach ($o->uninterpreted_option as $v) {
       $nv = new \google\protobuf\UninterpretedOption();
@@ -5481,10 +5481,10 @@ class MethodOptions implements \Protobuf\Message {
       return \Errors\Errorf('CopyFrom failed: incorrect type received: %s', $o->MessageName());
     }
     if ($o->hasDeprecated()) {
-      $this->deprecated = $o->deprecated;
+      $this->setDeprecated($o->getDeprecated());
     }
     if ($o->hasIdempotencyLevel()) {
-      $this->idempotency_level = $o->idempotency_level;
+      $this->setIdempotencyLevel($o->getIdempotencyLevel());
     }
     foreach ($o->uninterpreted_option as $v) {
       $nv = new \google\protobuf\UninterpretedOption();
@@ -5894,22 +5894,22 @@ class UninterpretedOption implements \Protobuf\Message {
       $this->name []= $nv;
     }
     if ($o->hasIdentifierValue()) {
-      $this->identifier_value = $o->identifier_value;
+      $this->setIdentifierValue($o->getIdentifierValue());
     }
     if ($o->hasPositiveIntValue()) {
-      $this->positive_int_value = $o->positive_int_value;
+      $this->setPositiveIntValue($o->getPositiveIntValue());
     }
     if ($o->hasNegativeIntValue()) {
-      $this->negative_int_value = $o->negative_int_value;
+      $this->setNegativeIntValue($o->getNegativeIntValue());
     }
     if ($o->hasDoubleValue()) {
-      $this->double_value = $o->double_value;
+      $this->setDoubleValue($o->getDoubleValue());
     }
     if ($o->hasStringValue()) {
-      $this->string_value = $o->string_value;
+      $this->setStringValue($o->getStringValue());
     }
     if ($o->hasAggregateValue()) {
-      $this->aggregate_value = $o->aggregate_value;
+      $this->setAggregateValue($o->getAggregateValue());
     }
     $this->XXX_unrecognized = $o->XXX_unrecognized;
     return \Errors\Ok();
@@ -6117,10 +6117,10 @@ class SourceCodeInfo_Location implements \Protobuf\Message {
     $this->path = $o->path;
     $this->span = $o->span;
     if ($o->hasLeadingComments()) {
-      $this->leading_comments = $o->leading_comments;
+      $this->setLeadingComments($o->getLeadingComments());
     }
     if ($o->hasTrailingComments()) {
-      $this->trailing_comments = $o->trailing_comments;
+      $this->setTrailingComments($o->getTrailingComments());
     }
     $this->leading_detached_comments = $o->leading_detached_comments;
     $this->XXX_unrecognized = $o->XXX_unrecognized;
@@ -6409,13 +6409,13 @@ class GeneratedCodeInfo_Annotation implements \Protobuf\Message {
     }
     $this->path = $o->path;
     if ($o->hasSourceFile()) {
-      $this->source_file = $o->source_file;
+      $this->setSourceFile($o->getSourceFile());
     }
     if ($o->hasBegin()) {
-      $this->begin = $o->begin;
+      $this->setBegin($o->getBegin());
     }
     if ($o->hasEnd()) {
-      $this->end = $o->end;
+      $this->setEnd($o->getEnd());
     }
     $this->XXX_unrecognized = $o->XXX_unrecognized;
     return \Errors\Ok();

--- a/generated/google/protobuf/test_messages_proto2_proto.php
+++ b/generated/google/protobuf/test_messages_proto2_proto.php
@@ -429,7 +429,7 @@ class TestAllTypesProto2_NestedMessage implements \Protobuf\Message {
       return \Errors\Errorf('CopyFrom failed: incorrect type received: %s', $o->MessageName());
     }
     if ($o->hasA()) {
-      $this->a = $o->a;
+      $this->setA($o->getA());
     }
     $tmp = $o->corecursive;
     if ($tmp is nonnull) {
@@ -575,10 +575,10 @@ class TestAllTypesProto2_MapInt32Int32Entry implements \Protobuf\Message {
       return \Errors\Errorf('CopyFrom failed: incorrect type received: %s', $o->MessageName());
     }
     if ($o->hasKey()) {
-      $this->key = $o->key;
+      $this->setKey($o->getKey());
     }
     if ($o->hasValue()) {
-      $this->value = $o->value;
+      $this->setValue($o->getValue());
     }
     $this->XXX_unrecognized = $o->XXX_unrecognized;
     return \Errors\Ok();
@@ -716,10 +716,10 @@ class TestAllTypesProto2_MapInt64Int64Entry implements \Protobuf\Message {
       return \Errors\Errorf('CopyFrom failed: incorrect type received: %s', $o->MessageName());
     }
     if ($o->hasKey()) {
-      $this->key = $o->key;
+      $this->setKey($o->getKey());
     }
     if ($o->hasValue()) {
-      $this->value = $o->value;
+      $this->setValue($o->getValue());
     }
     $this->XXX_unrecognized = $o->XXX_unrecognized;
     return \Errors\Ok();
@@ -857,10 +857,10 @@ class TestAllTypesProto2_MapUint32Uint32Entry implements \Protobuf\Message {
       return \Errors\Errorf('CopyFrom failed: incorrect type received: %s', $o->MessageName());
     }
     if ($o->hasKey()) {
-      $this->key = $o->key;
+      $this->setKey($o->getKey());
     }
     if ($o->hasValue()) {
-      $this->value = $o->value;
+      $this->setValue($o->getValue());
     }
     $this->XXX_unrecognized = $o->XXX_unrecognized;
     return \Errors\Ok();
@@ -998,10 +998,10 @@ class TestAllTypesProto2_MapUint64Uint64Entry implements \Protobuf\Message {
       return \Errors\Errorf('CopyFrom failed: incorrect type received: %s', $o->MessageName());
     }
     if ($o->hasKey()) {
-      $this->key = $o->key;
+      $this->setKey($o->getKey());
     }
     if ($o->hasValue()) {
-      $this->value = $o->value;
+      $this->setValue($o->getValue());
     }
     $this->XXX_unrecognized = $o->XXX_unrecognized;
     return \Errors\Ok();
@@ -1139,10 +1139,10 @@ class TestAllTypesProto2_MapSint32Sint32Entry implements \Protobuf\Message {
       return \Errors\Errorf('CopyFrom failed: incorrect type received: %s', $o->MessageName());
     }
     if ($o->hasKey()) {
-      $this->key = $o->key;
+      $this->setKey($o->getKey());
     }
     if ($o->hasValue()) {
-      $this->value = $o->value;
+      $this->setValue($o->getValue());
     }
     $this->XXX_unrecognized = $o->XXX_unrecognized;
     return \Errors\Ok();
@@ -1280,10 +1280,10 @@ class TestAllTypesProto2_MapSint64Sint64Entry implements \Protobuf\Message {
       return \Errors\Errorf('CopyFrom failed: incorrect type received: %s', $o->MessageName());
     }
     if ($o->hasKey()) {
-      $this->key = $o->key;
+      $this->setKey($o->getKey());
     }
     if ($o->hasValue()) {
-      $this->value = $o->value;
+      $this->setValue($o->getValue());
     }
     $this->XXX_unrecognized = $o->XXX_unrecognized;
     return \Errors\Ok();
@@ -1421,10 +1421,10 @@ class TestAllTypesProto2_MapFixed32Fixed32Entry implements \Protobuf\Message {
       return \Errors\Errorf('CopyFrom failed: incorrect type received: %s', $o->MessageName());
     }
     if ($o->hasKey()) {
-      $this->key = $o->key;
+      $this->setKey($o->getKey());
     }
     if ($o->hasValue()) {
-      $this->value = $o->value;
+      $this->setValue($o->getValue());
     }
     $this->XXX_unrecognized = $o->XXX_unrecognized;
     return \Errors\Ok();
@@ -1562,10 +1562,10 @@ class TestAllTypesProto2_MapFixed64Fixed64Entry implements \Protobuf\Message {
       return \Errors\Errorf('CopyFrom failed: incorrect type received: %s', $o->MessageName());
     }
     if ($o->hasKey()) {
-      $this->key = $o->key;
+      $this->setKey($o->getKey());
     }
     if ($o->hasValue()) {
-      $this->value = $o->value;
+      $this->setValue($o->getValue());
     }
     $this->XXX_unrecognized = $o->XXX_unrecognized;
     return \Errors\Ok();
@@ -1703,10 +1703,10 @@ class TestAllTypesProto2_MapSfixed32Sfixed32Entry implements \Protobuf\Message {
       return \Errors\Errorf('CopyFrom failed: incorrect type received: %s', $o->MessageName());
     }
     if ($o->hasKey()) {
-      $this->key = $o->key;
+      $this->setKey($o->getKey());
     }
     if ($o->hasValue()) {
-      $this->value = $o->value;
+      $this->setValue($o->getValue());
     }
     $this->XXX_unrecognized = $o->XXX_unrecognized;
     return \Errors\Ok();
@@ -1844,10 +1844,10 @@ class TestAllTypesProto2_MapSfixed64Sfixed64Entry implements \Protobuf\Message {
       return \Errors\Errorf('CopyFrom failed: incorrect type received: %s', $o->MessageName());
     }
     if ($o->hasKey()) {
-      $this->key = $o->key;
+      $this->setKey($o->getKey());
     }
     if ($o->hasValue()) {
-      $this->value = $o->value;
+      $this->setValue($o->getValue());
     }
     $this->XXX_unrecognized = $o->XXX_unrecognized;
     return \Errors\Ok();
@@ -1985,10 +1985,10 @@ class TestAllTypesProto2_MapInt32FloatEntry implements \Protobuf\Message {
       return \Errors\Errorf('CopyFrom failed: incorrect type received: %s', $o->MessageName());
     }
     if ($o->hasKey()) {
-      $this->key = $o->key;
+      $this->setKey($o->getKey());
     }
     if ($o->hasValue()) {
-      $this->value = $o->value;
+      $this->setValue($o->getValue());
     }
     $this->XXX_unrecognized = $o->XXX_unrecognized;
     return \Errors\Ok();
@@ -2126,10 +2126,10 @@ class TestAllTypesProto2_MapInt32DoubleEntry implements \Protobuf\Message {
       return \Errors\Errorf('CopyFrom failed: incorrect type received: %s', $o->MessageName());
     }
     if ($o->hasKey()) {
-      $this->key = $o->key;
+      $this->setKey($o->getKey());
     }
     if ($o->hasValue()) {
-      $this->value = $o->value;
+      $this->setValue($o->getValue());
     }
     $this->XXX_unrecognized = $o->XXX_unrecognized;
     return \Errors\Ok();
@@ -2267,10 +2267,10 @@ class TestAllTypesProto2_MapBoolBoolEntry implements \Protobuf\Message {
       return \Errors\Errorf('CopyFrom failed: incorrect type received: %s', $o->MessageName());
     }
     if ($o->hasKey()) {
-      $this->key = $o->key;
+      $this->setKey($o->getKey());
     }
     if ($o->hasValue()) {
-      $this->value = $o->value;
+      $this->setValue($o->getValue());
     }
     $this->XXX_unrecognized = $o->XXX_unrecognized;
     return \Errors\Ok();
@@ -2408,10 +2408,10 @@ class TestAllTypesProto2_MapStringStringEntry implements \Protobuf\Message {
       return \Errors\Errorf('CopyFrom failed: incorrect type received: %s', $o->MessageName());
     }
     if ($o->hasKey()) {
-      $this->key = $o->key;
+      $this->setKey($o->getKey());
     }
     if ($o->hasValue()) {
-      $this->value = $o->value;
+      $this->setValue($o->getValue());
     }
     $this->XXX_unrecognized = $o->XXX_unrecognized;
     return \Errors\Ok();
@@ -2549,10 +2549,10 @@ class TestAllTypesProto2_MapStringBytesEntry implements \Protobuf\Message {
       return \Errors\Errorf('CopyFrom failed: incorrect type received: %s', $o->MessageName());
     }
     if ($o->hasKey()) {
-      $this->key = $o->key;
+      $this->setKey($o->getKey());
     }
     if ($o->hasValue()) {
-      $this->value = $o->value;
+      $this->setValue($o->getValue());
     }
     $this->XXX_unrecognized = $o->XXX_unrecognized;
     return \Errors\Ok();
@@ -2701,7 +2701,7 @@ class TestAllTypesProto2_MapStringNestedMessageEntry implements \Protobuf\Messag
       return \Errors\Errorf('CopyFrom failed: incorrect type received: %s', $o->MessageName());
     }
     if ($o->hasKey()) {
-      $this->key = $o->key;
+      $this->setKey($o->getKey());
     }
     $tmp = $o->value;
     if ($tmp is nonnull) {
@@ -2858,7 +2858,7 @@ class TestAllTypesProto2_MapStringForeignMessageEntry implements \Protobuf\Messa
       return \Errors\Errorf('CopyFrom failed: incorrect type received: %s', $o->MessageName());
     }
     if ($o->hasKey()) {
-      $this->key = $o->key;
+      $this->setKey($o->getKey());
     }
     $tmp = $o->value;
     if ($tmp is nonnull) {
@@ -3004,10 +3004,10 @@ class TestAllTypesProto2_MapStringNestedEnumEntry implements \Protobuf\Message {
       return \Errors\Errorf('CopyFrom failed: incorrect type received: %s', $o->MessageName());
     }
     if ($o->hasKey()) {
-      $this->key = $o->key;
+      $this->setKey($o->getKey());
     }
     if ($o->hasValue()) {
-      $this->value = $o->value;
+      $this->setValue($o->getValue());
     }
     $this->XXX_unrecognized = $o->XXX_unrecognized;
     return \Errors\Ok();
@@ -3145,10 +3145,10 @@ class TestAllTypesProto2_MapStringForeignEnumEntry implements \Protobuf\Message 
       return \Errors\Errorf('CopyFrom failed: incorrect type received: %s', $o->MessageName());
     }
     if ($o->hasKey()) {
-      $this->key = $o->key;
+      $this->setKey($o->getKey());
     }
     if ($o->hasValue()) {
-      $this->value = $o->value;
+      $this->setValue($o->getValue());
     }
     $this->XXX_unrecognized = $o->XXX_unrecognized;
     return \Errors\Ok();
@@ -3286,10 +3286,10 @@ class TestAllTypesProto2_Data implements \Protobuf\Message {
       return \Errors\Errorf('CopyFrom failed: incorrect type received: %s', $o->MessageName());
     }
     if ($o->hasGroupInt32()) {
-      $this->group_int32 = $o->group_int32;
+      $this->setGroupInt32($o->getGroupInt32());
     }
     if ($o->hasGroupUint32()) {
-      $this->group_uint32 = $o->group_uint32;
+      $this->setGroupUint32($o->getGroupUint32());
     }
     $this->XXX_unrecognized = $o->XXX_unrecognized;
     return \Errors\Ok();
@@ -3448,7 +3448,7 @@ class TestAllTypesProto2_MessageSetCorrectExtension1 implements \Protobuf\Messag
       return \Errors\Errorf('CopyFrom failed: incorrect type received: %s', $o->MessageName());
     }
     if ($o->hasStr()) {
-      $this->str = $o->str;
+      $this->setStr($o->getStr());
     }
     $this->XXX_unrecognized = $o->XXX_unrecognized;
     return \Errors\Ok();
@@ -3548,7 +3548,7 @@ class TestAllTypesProto2_MessageSetCorrectExtension2 implements \Protobuf\Messag
       return \Errors\Errorf('CopyFrom failed: incorrect type received: %s', $o->MessageName());
     }
     if ($o->hasI()) {
-      $this->i = $o->i;
+      $this->setI($o->getI());
     }
     $this->XXX_unrecognized = $o->XXX_unrecognized;
     return \Errors\Ok();
@@ -7446,49 +7446,49 @@ class TestAllTypesProto2 implements \Protobuf\Message {
       return \Errors\Errorf('CopyFrom failed: incorrect type received: %s', $o->MessageName());
     }
     if ($o->hasOptionalInt32()) {
-      $this->optional_int32 = $o->optional_int32;
+      $this->setOptionalInt32($o->getOptionalInt32());
     }
     if ($o->hasOptionalInt64()) {
-      $this->optional_int64 = $o->optional_int64;
+      $this->setOptionalInt64($o->getOptionalInt64());
     }
     if ($o->hasOptionalUint32()) {
-      $this->optional_uint32 = $o->optional_uint32;
+      $this->setOptionalUint32($o->getOptionalUint32());
     }
     if ($o->hasOptionalUint64()) {
-      $this->optional_uint64 = $o->optional_uint64;
+      $this->setOptionalUint64($o->getOptionalUint64());
     }
     if ($o->hasOptionalSint32()) {
-      $this->optional_sint32 = $o->optional_sint32;
+      $this->setOptionalSint32($o->getOptionalSint32());
     }
     if ($o->hasOptionalSint64()) {
-      $this->optional_sint64 = $o->optional_sint64;
+      $this->setOptionalSint64($o->getOptionalSint64());
     }
     if ($o->hasOptionalFixed32()) {
-      $this->optional_fixed32 = $o->optional_fixed32;
+      $this->setOptionalFixed32($o->getOptionalFixed32());
     }
     if ($o->hasOptionalFixed64()) {
-      $this->optional_fixed64 = $o->optional_fixed64;
+      $this->setOptionalFixed64($o->getOptionalFixed64());
     }
     if ($o->hasOptionalSfixed32()) {
-      $this->optional_sfixed32 = $o->optional_sfixed32;
+      $this->setOptionalSfixed32($o->getOptionalSfixed32());
     }
     if ($o->hasOptionalSfixed64()) {
-      $this->optional_sfixed64 = $o->optional_sfixed64;
+      $this->setOptionalSfixed64($o->getOptionalSfixed64());
     }
     if ($o->hasOptionalFloat()) {
-      $this->optional_float = $o->optional_float;
+      $this->setOptionalFloat($o->getOptionalFloat());
     }
     if ($o->hasOptionalDouble()) {
-      $this->optional_double = $o->optional_double;
+      $this->setOptionalDouble($o->getOptionalDouble());
     }
     if ($o->hasOptionalBool()) {
-      $this->optional_bool = $o->optional_bool;
+      $this->setOptionalBool($o->getOptionalBool());
     }
     if ($o->hasOptionalString()) {
-      $this->optional_string = $o->optional_string;
+      $this->setOptionalString($o->getOptionalString());
     }
     if ($o->hasOptionalBytes()) {
-      $this->optional_bytes = $o->optional_bytes;
+      $this->setOptionalBytes($o->getOptionalBytes());
     }
     $tmp = $o->optional_nested_message;
     if ($tmp is nonnull) {
@@ -7507,16 +7507,16 @@ class TestAllTypesProto2 implements \Protobuf\Message {
       $this->setOptionalForeignMessage(null);
     }
     if ($o->hasOptionalNestedEnum()) {
-      $this->optional_nested_enum = $o->optional_nested_enum;
+      $this->setOptionalNestedEnum($o->getOptionalNestedEnum());
     }
     if ($o->hasOptionalForeignEnum()) {
-      $this->optional_foreign_enum = $o->optional_foreign_enum;
+      $this->setOptionalForeignEnum($o->getOptionalForeignEnum());
     }
     if ($o->hasOptionalStringPiece()) {
-      $this->optional_string_piece = $o->optional_string_piece;
+      $this->setOptionalStringPiece($o->getOptionalStringPiece());
     }
     if ($o->hasOptionalCord()) {
-      $this->optional_cord = $o->optional_cord;
+      $this->setOptionalCord($o->getOptionalCord());
     }
     $tmp = $o->recursive_message;
     if ($tmp is nonnull) {
@@ -7619,103 +7619,103 @@ class TestAllTypesProto2 implements \Protobuf\Message {
       $this->setData(null);
     }
     if ($o->hasDefaultInt32()) {
-      $this->default_int32 = $o->default_int32;
+      $this->setDefaultInt32($o->getDefaultInt32());
     }
     if ($o->hasDefaultInt64()) {
-      $this->default_int64 = $o->default_int64;
+      $this->setDefaultInt64($o->getDefaultInt64());
     }
     if ($o->hasDefaultUint32()) {
-      $this->default_uint32 = $o->default_uint32;
+      $this->setDefaultUint32($o->getDefaultUint32());
     }
     if ($o->hasDefaultUint64()) {
-      $this->default_uint64 = $o->default_uint64;
+      $this->setDefaultUint64($o->getDefaultUint64());
     }
     if ($o->hasDefaultSint32()) {
-      $this->default_sint32 = $o->default_sint32;
+      $this->setDefaultSint32($o->getDefaultSint32());
     }
     if ($o->hasDefaultSint64()) {
-      $this->default_sint64 = $o->default_sint64;
+      $this->setDefaultSint64($o->getDefaultSint64());
     }
     if ($o->hasDefaultFixed32()) {
-      $this->default_fixed32 = $o->default_fixed32;
+      $this->setDefaultFixed32($o->getDefaultFixed32());
     }
     if ($o->hasDefaultFixed64()) {
-      $this->default_fixed64 = $o->default_fixed64;
+      $this->setDefaultFixed64($o->getDefaultFixed64());
     }
     if ($o->hasDefaultSfixed32()) {
-      $this->default_sfixed32 = $o->default_sfixed32;
+      $this->setDefaultSfixed32($o->getDefaultSfixed32());
     }
     if ($o->hasDefaultSfixed64()) {
-      $this->default_sfixed64 = $o->default_sfixed64;
+      $this->setDefaultSfixed64($o->getDefaultSfixed64());
     }
     if ($o->hasDefaultFloat()) {
-      $this->default_float = $o->default_float;
+      $this->setDefaultFloat($o->getDefaultFloat());
     }
     if ($o->hasDefaultDouble()) {
-      $this->default_double = $o->default_double;
+      $this->setDefaultDouble($o->getDefaultDouble());
     }
     if ($o->hasDefaultBool()) {
-      $this->default_bool = $o->default_bool;
+      $this->setDefaultBool($o->getDefaultBool());
     }
     if ($o->hasDefaultString()) {
-      $this->default_string = $o->default_string;
+      $this->setDefaultString($o->getDefaultString());
     }
     if ($o->hasDefaultBytes()) {
-      $this->default_bytes = $o->default_bytes;
+      $this->setDefaultBytes($o->getDefaultBytes());
     }
     if ($o->hasFieldname1()) {
-      $this->fieldname1 = $o->fieldname1;
+      $this->setFieldname1($o->getFieldname1());
     }
     if ($o->hasFieldName2()) {
-      $this->field_name2 = $o->field_name2;
+      $this->setFieldName2($o->getFieldName2());
     }
     if ($o->hasFieldName3()) {
-      $this->_field_name3 = $o->_field_name3;
+      $this->setFieldName3($o->getFieldName3());
     }
     if ($o->hasFieldName4()) {
-      $this->field__name4_ = $o->field__name4_;
+      $this->setFieldName4($o->getFieldName4());
     }
     if ($o->hasField0name5()) {
-      $this->field0name5 = $o->field0name5;
+      $this->setField0name5($o->getField0name5());
     }
     if ($o->hasField0Name6()) {
-      $this->field_0_name6 = $o->field_0_name6;
+      $this->setField0Name6($o->getField0Name6());
     }
     if ($o->hasFieldName7()) {
-      $this->fieldName7 = $o->fieldName7;
+      $this->setFieldName7($o->getFieldName7());
     }
     if ($o->hasFieldName8()) {
-      $this->FieldName8 = $o->FieldName8;
+      $this->setFieldName8($o->getFieldName8());
     }
     if ($o->hasFieldName9()) {
-      $this->field_Name9 = $o->field_Name9;
+      $this->setFieldName9($o->getFieldName9());
     }
     if ($o->hasFieldName10()) {
-      $this->Field_Name10 = $o->Field_Name10;
+      $this->setFieldName10($o->getFieldName10());
     }
     if ($o->hasFIELDNAME11()) {
-      $this->FIELD_NAME11 = $o->FIELD_NAME11;
+      $this->setFIELDNAME11($o->getFIELDNAME11());
     }
     if ($o->hasFIELDName12()) {
-      $this->FIELD_name12 = $o->FIELD_name12;
+      $this->setFIELDName12($o->getFIELDName12());
     }
     if ($o->hasFieldName13()) {
-      $this->__field_name13 = $o->__field_name13;
+      $this->setFieldName13($o->getFieldName13());
     }
     if ($o->hasFieldName14()) {
-      $this->__Field_name14 = $o->__Field_name14;
+      $this->setFieldName14($o->getFieldName14());
     }
     if ($o->hasFieldName15()) {
-      $this->field__name15 = $o->field__name15;
+      $this->setFieldName15($o->getFieldName15());
     }
     if ($o->hasFieldName16()) {
-      $this->field__Name16 = $o->field__Name16;
+      $this->setFieldName16($o->getFieldName16());
     }
     if ($o->hasFieldName17()) {
-      $this->field_name17__ = $o->field_name17__;
+      $this->setFieldName17($o->getFieldName17());
     }
     if ($o->hasFieldName18()) {
-      $this->Field_name18__ = $o->Field_name18__;
+      $this->setFieldName18($o->getFieldName18());
     }
     $this->oneof_field = $o->oneof_field->Copy();
     $this->XXX_unrecognized = $o->XXX_unrecognized;
@@ -7816,7 +7816,7 @@ class ForeignMessageProto2 implements \Protobuf\Message {
       return \Errors\Errorf('CopyFrom failed: incorrect type received: %s', $o->MessageName());
     }
     if ($o->hasC()) {
-      $this->c = $o->c;
+      $this->setC($o->getC());
     }
     $this->XXX_unrecognized = $o->XXX_unrecognized;
     return \Errors\Ok();
@@ -7916,7 +7916,7 @@ class UnknownToTestAllTypes_OptionalGroup implements \Protobuf\Message {
       return \Errors\Errorf('CopyFrom failed: incorrect type received: %s', $o->MessageName());
     }
     if ($o->hasA()) {
-      $this->a = $o->a;
+      $this->setA($o->getA());
     }
     $this->XXX_unrecognized = $o->XXX_unrecognized;
     return \Errors\Ok();
@@ -8213,10 +8213,10 @@ class UnknownToTestAllTypes implements \Protobuf\Message {
       return \Errors\Errorf('CopyFrom failed: incorrect type received: %s', $o->MessageName());
     }
     if ($o->hasOptionalInt32()) {
-      $this->optional_int32 = $o->optional_int32;
+      $this->setOptionalInt32($o->getOptionalInt32());
     }
     if ($o->hasOptionalString()) {
-      $this->optional_string = $o->optional_string;
+      $this->setOptionalString($o->getOptionalString());
     }
     $tmp = $o->nested_message;
     if ($tmp is nonnull) {
@@ -8235,7 +8235,7 @@ class UnknownToTestAllTypes implements \Protobuf\Message {
       $this->setOptionalgroup(null);
     }
     if ($o->hasOptionalBool()) {
-      $this->optional_bool = $o->optional_bool;
+      $this->setOptionalBool($o->getOptionalBool());
     }
     $this->repeated_int32 = $o->repeated_int32;
     $this->XXX_unrecognized = $o->XXX_unrecognized;
@@ -8479,7 +8479,7 @@ class OneStringProto2 implements \Protobuf\Message {
       return \Errors\Errorf('CopyFrom failed: incorrect type received: %s', $o->MessageName());
     }
     if ($o->hasData()) {
-      $this->data = $o->data;
+      $this->setData($o->getData());
     }
     $this->XXX_unrecognized = $o->XXX_unrecognized;
     return \Errors\Ok();

--- a/generated/test/optional_proto3_proto.php
+++ b/generated/test/optional_proto3_proto.php
@@ -484,22 +484,22 @@ class optional_proto3 implements \Protobuf\Message {
       return \Errors\Errorf('CopyFrom failed: incorrect type received: %s', $o->MessageName());
     }
     if ($o->hasAdouble()) {
-      $this->adouble = $o->adouble;
+      $this->setAdouble($o->getAdouble());
     }
     if ($o->hasAint64()) {
-      $this->aint64 = $o->aint64;
+      $this->setAint64($o->getAint64());
     }
     if ($o->hasAbool()) {
-      $this->abool = $o->abool;
+      $this->setAbool($o->getAbool());
     }
     if ($o->hasAstring()) {
-      $this->astring = $o->astring;
+      $this->setAstring($o->getAstring());
     }
     if ($o->hasAbytes()) {
-      $this->abytes = $o->abytes;
+      $this->setAbytes($o->getAbytes());
     }
     if ($o->hasAnenum()) {
-      $this->anenum = $o->anenum;
+      $this->setAnenum($o->getAnenum());
     }
     $tmp = $o->amsg;
     if ($tmp is nonnull) {

--- a/generated/test/proto2_ex1_proto.php
+++ b/generated/test/proto2_ex1_proto.php
@@ -367,25 +367,25 @@ class example1 implements \Protobuf\Message {
       return \Errors\Errorf('CopyFrom failed: incorrect type received: %s', $o->MessageName());
     }
     if ($o->hasEnumDefault()) {
-      $this->enum_default = $o->enum_default;
+      $this->setEnumDefault($o->getEnumDefault());
     }
     if ($o->hasEnumCustom()) {
-      $this->enum_custom = $o->enum_custom;
+      $this->setEnumCustom($o->getEnumCustom());
     }
     if ($o->hasAdouble()) {
-      $this->adouble = $o->adouble;
+      $this->setAdouble($o->getAdouble());
     }
     if ($o->hasAfloat()) {
-      $this->afloat = $o->afloat;
+      $this->setAfloat($o->getAfloat());
     }
     if ($o->hasAbool()) {
-      $this->abool = $o->abool;
+      $this->setAbool($o->getAbool());
     }
     if ($o->hasAstring()) {
-      $this->astring = $o->astring;
+      $this->setAstring($o->getAstring());
     }
     if ($o->hasAbytes()) {
-      $this->abytes = $o->abytes;
+      $this->setAbytes($o->getAbytes());
     }
     $this->required_field = $o->required_field;
     $this->XXX_unrecognized = $o->XXX_unrecognized;

--- a/protoc-gen-hack/plugin.go
+++ b/protoc-gen-hack/plugin.go
@@ -866,10 +866,10 @@ func (f field) writeCopy(w *writer, c string) {
 		if f.isOptional() {
 			camelCaseName := camelCase(f.varName())
 			w.p("if (%s->has%s()) {", c, camelCaseName)
-		}
-		w.p("$this->%s = %s->%s;", f.varName(), c, f.varName())
-		if f.isOptional() {
+			w.p("$this->set%s(%s->get%s());", camelCaseName, c, camelCaseName)
 			w.p("}")
+		} else {
+			w.p("$this->%s = %s->%s;", f.varName(), c, f.varName())
 		}
 	}
 }


### PR DESCRIPTION
There was an issue where optional syntax wasn't setting the `was_[name]_set` value.
Changing to use `$this->set[name]` instead when there's an optional field
